### PR TITLE
Prepare for supporting vhost-net

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 39.8, "exclude_path": "", "crate_features": "vhost-vsock,vhost-kern,vhost-user-master,vhost-user-slave"}
+{"coverage_score": 40.2, "exclude_path": "", "crate_features": "vhost-vsock,vhost-kern,vhost-user-master,vhost-user-slave"}

--- a/src/vhost_kern/mod.rs
+++ b/src/vhost_kern/mod.rs
@@ -13,7 +13,7 @@
 
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestUsize};
+use vm_memory::GuestAddressSpace;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref};
 
@@ -38,12 +38,12 @@ fn ioctl_result<T>(rc: i32, res: T) -> Result<T> {
 }
 
 /// Represent an in-kernel vhost device backend.
-pub trait VhostKernBackend<'a>: AsRawFd {
+pub trait VhostKernBackend: AsRawFd {
     /// Assoicated type to access guest memory.
-    type M: GuestMemory;
+    type AS: GuestAddressSpace;
 
     /// Get the object to access the guest's memory.
-    fn mem(&self) -> &Self::M;
+    fn mem(&self) -> &Self::AS;
 
     /// Check whether the ring configuration is valid.
     fn is_valid(&self, config_data: &VringConfigData) -> bool {
@@ -84,7 +84,7 @@ pub trait VhostKernBackend<'a>: AsRawFd {
     }
 }
 
-impl<'a, T: VhostKernBackend<'a>> VhostBackend for T {
+impl<T: VhostKernBackend> VhostBackend for T {
     /// Set the current process as the owner of this file descriptor.
     /// This must be run before any other vhost ioctls.
     fn set_owner(&mut self) -> Result<()> {

--- a/src/vhost_kern/vhost_binding.rs
+++ b/src/vhost_kern/vhost_binding.rs
@@ -14,8 +14,8 @@
 #![allow(non_snake_case)]
 #![allow(missing_docs)]
 
+use crate::{Error, Result};
 use std::os::raw;
-use {Error, Result};
 
 pub const VHOST: raw::c_uint = 0xaf;
 pub const VHOST_VRING_F_LOG: raw::c_uint = 0;
@@ -49,7 +49,7 @@ ioctl_iowr_nr!(VHOST_GET_VRING_BASE, VHOST, 0x12, vhost_vring_state);
 ioctl_iow_nr!(VHOST_SET_VRING_KICK, VHOST, 0x20, vhost_vring_file);
 ioctl_iow_nr!(VHOST_SET_VRING_CALL, VHOST, 0x21, vhost_vring_file);
 ioctl_iow_nr!(VHOST_SET_VRING_ERR, VHOST, 0x22, vhost_vring_file);
-ioctl_iow_nr!(vhost_SET_BACKEND, VHOST, 0x30, vhost_vring_file);
+ioctl_iow_nr!(VHOST_NET_SET_BACKEND, VHOST, 0x30, vhost_vring_file);
 ioctl_iow_nr!(VHOST_SCSI_SET_ENDPOINT, VHOST, 0x40, vhost_scsi_target);
 ioctl_iow_nr!(VHOST_SCSI_CLEAR_ENDPOINT, VHOST, 0x41, vhost_scsi_target);
 ioctl_iow_nr!(VHOST_SCSI_GET_ABI_VERSION, VHOST, 0x42, raw::c_int);

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -11,7 +11,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use VringConfigData;
+use crate::VringConfigData;
 
 /// The vhost-user specification uses a field of u32 to store message length.
 /// On the other hand, preallocated buffers are needed to receive messages from the Unix domain
@@ -37,7 +37,7 @@ pub const VHOST_USER_CONFIG_OFFSET: u32 = 0x100;
 pub const VHOST_USER_CONFIG_SIZE: u32 = 0x1000;
 
 /// Maximum number of vrings supported.
-pub const VHOST_USER_MAX_VRINGS: u64 = 0xFFu64;
+pub const VHOST_USER_MAX_VRINGS: u64 = 0x8000u64;
 
 pub(super) trait Req:
     Clone + Copy + Debug + PartialEq + Eq + PartialOrd + Ord + Into<u32>


### PR DESCRIPTION
This is a misc patch series, which includes:

fixes one bug in vring address handling
upgrade to latest vm-memory
fix a typo
enlarge VHOST_USER_MAX_VRINGS to 0x8000

Fix of the previous PR #11