### PR TITLE
Polish vhost-kern related code for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/build
+/kcov_build
 /target
+.idea
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.1.0"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]
 repository = "https://github.com/rust-vmm/vhost"
 license = "Apache-2.0 or BSD-3-Clause"
+edition = "2018"
 
 [features]
 default = []
 vhost-vsock = []
 vhost-kern = ["vm-memory"]
-vhost-user-master = []
-vhost-user-slave = []
+vhost-user = []
+vhost-user-master = ["vhost-user"]
+vhost-user-slave = ["vhost-user"]
 
 [dependencies]
 bitflags = ">=1.0.1"
@@ -18,3 +20,6 @@ libc = ">=0.2.39"
 
 vmm-sys-util = ">=0.3.1"
 vm-memory = { version = "0.2.0", optional = true }
+
+[dev-dependencies]
+vm-memory = { version = "0.2.0", features=["backend-mmap"] }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 40.2, "exclude_path": "", "crate_features": "vhost-vsock,vhost-kern,vhost-user-master,vhost-user-slave"}
+{"coverage_score": 73.3, "exclude_path": "src/vhost_kern/", "crate_features": ""}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+// Copyright (C) 2019-2021 Alibaba Cloud. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 //
 // Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -9,14 +9,18 @@
 
 //! Common traits and structs for vhost-kern and vhost-user backend drivers.
 
-use super::Result;
+use std::cell::RefCell;
 use std::os::unix::io::RawFd;
+use std::sync::RwLock;
+
 use vmm_sys_util::eventfd::EventFd;
+
+use super::Result;
 
 /// Maximum number of memory regions supported.
 pub const VHOST_MAX_MEMORY_REGIONS: usize = 255;
 
-/// Vring/virtque configuration data.
+/// Vring configuration data.
 pub struct VringConfigData {
     /// Maximum queue size supported by the driver.
     pub queue_max_size: u16,
@@ -65,8 +69,94 @@ pub struct VhostUserMemoryRegionInfo {
     pub userspace_addr: u64,
     /// Optional offset where region starts in the mapped memory.
     pub mmap_offset: u64,
-    /// Optional file diescriptor for mmap
+    /// Optional file descriptor for mmap.
     pub mmap_handle: RawFd,
+}
+
+/// An interface for setting up vhost-based backend drivers with interior mutability.
+///
+/// Vhost devices are subset of virtio devices, which improve virtio device's performance by
+/// delegating data plane operations to dedicated IO service processes. Vhost devices use the
+/// same virtqueue layout as virtio devices to allow vhost devices to be mapped directly to
+/// virtio devices.
+///
+/// The purpose of vhost is to implement a subset of a virtio device's functionality outside the
+/// VMM process. Typically fast paths for IO operations are delegated to the dedicated IO service
+/// processes, and slow path for device configuration are still handled by the VMM process. It may
+/// also be used to control access permissions of virtio backend devices.
+pub trait VhostBackend: std::marker::Sized {
+    /// Get a bitmask of supported virtio/vhost features.
+    fn get_features(&self) -> Result<u64>;
+
+    /// Inform the vhost subsystem which features to enable.
+    /// This should be a subset of supported features from get_features().
+    ///
+    /// # Arguments
+    /// * `features` - Bitmask of features to set.
+    fn set_features(&self, features: u64) -> Result<()>;
+
+    /// Set the current process as the owner of the vhost backend.
+    /// This must be run before any other vhost commands.
+    fn set_owner(&self) -> Result<()>;
+
+    /// Used to be sent to request disabling all rings
+    /// This is no longer used.
+    fn reset_owner(&self) -> Result<()>;
+
+    /// Set the guest memory mappings for vhost to use.
+    fn set_mem_table(&self, regions: &[VhostUserMemoryRegionInfo]) -> Result<()>;
+
+    /// Set base address for page modification logging.
+    fn set_log_base(&self, base: u64, fd: Option<RawFd>) -> Result<()>;
+
+    /// Specify an eventfd file descriptor to signal on log write.
+    fn set_log_fd(&self, fd: RawFd) -> Result<()>;
+
+    /// Set the number of descriptors in the vring.
+    ///
+    /// # Arguments
+    /// * `queue_index` - Index of the queue to set descriptor count for.
+    /// * `num` - Number of descriptors in the queue.
+    fn set_vring_num(&self, queue_index: usize, num: u16) -> Result<()>;
+
+    /// Set the addresses for a given vring.
+    ///
+    /// # Arguments
+    /// * `queue_index` - Index of the queue to set addresses for.
+    /// * `config_data` - Configuration data for a vring.
+    fn set_vring_addr(&self, queue_index: usize, config_data: &VringConfigData) -> Result<()>;
+
+    /// Set the first index to look for available descriptors.
+    ///
+    /// # Arguments
+    /// * `queue_index` - Index of the queue to modify.
+    /// * `num` - Index where available descriptors start.
+    fn set_vring_base(&self, queue_index: usize, base: u16) -> Result<()>;
+
+    /// Get the available vring base offset.
+    fn get_vring_base(&self, queue_index: usize) -> Result<u32>;
+
+    /// Set the eventfd to trigger when buffers have been used by the host.
+    ///
+    /// # Arguments
+    /// * `queue_index` - Index of the queue to modify.
+    /// * `fd` - EventFd to trigger.
+    fn set_vring_call(&self, queue_index: usize, fd: &EventFd) -> Result<()>;
+
+    /// Set the eventfd that will be signaled by the guest when buffers are
+    /// available for the host to process.
+    ///
+    /// # Arguments
+    /// * `queue_index` - Index of the queue to modify.
+    /// * `fd` - EventFd that will be signaled from guest.
+    fn set_vring_kick(&self, queue_index: usize, fd: &EventFd) -> Result<()>;
+
+    /// Set the eventfd that will be signaled by the guest when error happens.
+    ///
+    /// # Arguments
+    /// * `queue_index` - Index of the queue to modify.
+    /// * `fd` - EventFd that will be signaled from guest.
+    fn set_vring_err(&self, queue_index: usize, fd: &EventFd) -> Result<()>;
 }
 
 /// An interface for setting up vhost-based backend drivers.
@@ -75,11 +165,12 @@ pub struct VhostUserMemoryRegionInfo {
 /// delegating data plane operations to dedicated IO service processes. Vhost devices use the
 /// same virtqueue layout as virtio devices to allow vhost devices to be mapped directly to
 /// virtio devices.
+///
 /// The purpose of vhost is to implement a subset of a virtio device's functionality outside the
 /// VMM process. Typically fast paths for IO operations are delegated to the dedicated IO service
 /// processes, and slow path for device configuration are still handled by the VMM process. It may
 /// also be used to control access permissions of virtio backend devices.
-pub trait VhostBackend: std::marker::Sized {
+pub trait VhostBackendMut: std::marker::Sized {
     /// Get a bitmask of supported virtio/vhost features.
     fn get_features(&mut self) -> Result<u64>;
 
@@ -154,9 +245,236 @@ pub trait VhostBackend: std::marker::Sized {
     fn set_vring_err(&mut self, queue_index: usize, fd: &EventFd) -> Result<()>;
 }
 
+impl<T: VhostBackendMut> VhostBackend for RwLock<T> {
+    fn get_features(&self) -> Result<u64> {
+        self.write().unwrap().get_features()
+    }
+
+    fn set_features(&self, features: u64) -> Result<()> {
+        self.write().unwrap().set_features(features)
+    }
+
+    fn set_owner(&self) -> Result<()> {
+        self.write().unwrap().set_owner()
+    }
+
+    fn reset_owner(&self) -> Result<()> {
+        self.write().unwrap().reset_owner()
+    }
+
+    fn set_mem_table(&self, regions: &[VhostUserMemoryRegionInfo]) -> Result<()> {
+        self.write().unwrap().set_mem_table(regions)
+    }
+
+    fn set_log_base(&self, base: u64, fd: Option<RawFd>) -> Result<()> {
+        self.write().unwrap().set_log_base(base, fd)
+    }
+
+    fn set_log_fd(&self, fd: RawFd) -> Result<()> {
+        self.write().unwrap().set_log_fd(fd)
+    }
+
+    fn set_vring_num(&self, queue_index: usize, num: u16) -> Result<()> {
+        self.write().unwrap().set_vring_num(queue_index, num)
+    }
+
+    fn set_vring_addr(&self, queue_index: usize, config_data: &VringConfigData) -> Result<()> {
+        self.write()
+            .unwrap()
+            .set_vring_addr(queue_index, config_data)
+    }
+
+    fn set_vring_base(&self, queue_index: usize, base: u16) -> Result<()> {
+        self.write().unwrap().set_vring_base(queue_index, base)
+    }
+
+    fn get_vring_base(&self, queue_index: usize) -> Result<u32> {
+        self.write().unwrap().get_vring_base(queue_index)
+    }
+
+    fn set_vring_call(&self, queue_index: usize, fd: &EventFd) -> Result<()> {
+        self.write().unwrap().set_vring_call(queue_index, fd)
+    }
+
+    fn set_vring_kick(&self, queue_index: usize, fd: &EventFd) -> Result<()> {
+        self.write().unwrap().set_vring_kick(queue_index, fd)
+    }
+
+    fn set_vring_err(&self, queue_index: usize, fd: &EventFd) -> Result<()> {
+        self.write().unwrap().set_vring_err(queue_index, fd)
+    }
+}
+
+impl<T: VhostBackendMut> VhostBackend for RefCell<T> {
+    fn get_features(&self) -> Result<u64> {
+        self.borrow_mut().get_features()
+    }
+
+    fn set_features(&self, features: u64) -> Result<()> {
+        self.borrow_mut().set_features(features)
+    }
+
+    fn set_owner(&self) -> Result<()> {
+        self.borrow_mut().set_owner()
+    }
+
+    fn reset_owner(&self) -> Result<()> {
+        self.borrow_mut().reset_owner()
+    }
+
+    fn set_mem_table(&self, regions: &[VhostUserMemoryRegionInfo]) -> Result<()> {
+        self.borrow_mut().set_mem_table(regions)
+    }
+
+    fn set_log_base(&self, base: u64, fd: Option<RawFd>) -> Result<()> {
+        self.borrow_mut().set_log_base(base, fd)
+    }
+
+    fn set_log_fd(&self, fd: RawFd) -> Result<()> {
+        self.borrow_mut().set_log_fd(fd)
+    }
+
+    fn set_vring_num(&self, queue_index: usize, num: u16) -> Result<()> {
+        self.borrow_mut().set_vring_num(queue_index, num)
+    }
+
+    fn set_vring_addr(&self, queue_index: usize, config_data: &VringConfigData) -> Result<()> {
+        self.borrow_mut().set_vring_addr(queue_index, config_data)
+    }
+
+    fn set_vring_base(&self, queue_index: usize, base: u16) -> Result<()> {
+        self.borrow_mut().set_vring_base(queue_index, base)
+    }
+
+    fn get_vring_base(&self, queue_index: usize) -> Result<u32> {
+        self.borrow_mut().get_vring_base(queue_index)
+    }
+
+    fn set_vring_call(&self, queue_index: usize, fd: &EventFd) -> Result<()> {
+        self.borrow_mut().set_vring_call(queue_index, fd)
+    }
+
+    fn set_vring_kick(&self, queue_index: usize, fd: &EventFd) -> Result<()> {
+        self.borrow_mut().set_vring_kick(queue_index, fd)
+    }
+
+    fn set_vring_err(&self, queue_index: usize, fd: &EventFd) -> Result<()> {
+        self.borrow_mut().set_vring_err(queue_index, fd)
+    }
+}
 #[cfg(test)]
 mod tests {
     use VringConfigData;
+
+    struct MockBackend {}
+
+    impl VhostBackendMut for MockBackend {
+        fn get_features(&mut self) -> Result<u64> {
+            Ok(0x1)
+        }
+
+        fn set_features(&mut self, features: u64) -> Result<()> {
+            assert_eq!(features, 0x1);
+            Ok(())
+        }
+
+        fn set_owner(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn reset_owner(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn set_mem_table(&mut self, regions: &[VhostUserMemoryRegionInfo]) -> Result<()> {
+            Ok(())
+        }
+
+        fn set_log_base(&mut self, base: u64, fd: Option<RawFd>) -> Result<()> {
+            assert_eq!(base, 0x100);
+            assert_eq!(fd, Some(100));
+            Ok(())
+        }
+
+        fn set_log_fd(&mut self, fd: RawFd) -> Result<()> {
+            assert_eq!(fd, 100);
+            Ok(())
+        }
+
+        fn set_vring_num(&mut self, queue_index: usize, num: u16) -> Result<()> {
+            assert_eq!(queue_index, 1);
+            assert_eq!(num, 256);
+            Ok(())
+        }
+
+        fn set_vring_addr(
+            &mut self,
+            queue_index: usize,
+            config_data: &VringConfigData,
+        ) -> Result<()> {
+            assert_eq!(queue_index, 1);
+            Ok(())
+        }
+
+        fn set_vring_base(&mut self, queue_index: usize, base: u16) -> Result<()> {
+            assert_eq!(queue_index, 1);
+            assert_eq!(base, 2);
+            Ok(())
+        }
+
+        fn get_vring_base(&mut self, queue_index: usize) -> Result<u32> {
+            assert_eq!(queue_index, 1);
+            Ok(2)
+        }
+
+        fn set_vring_call(&mut self, queue_index: usize, fd: &EventFd) -> Result<()> {
+            assert_eq!(queue_index, 1);
+            Ok(())
+        }
+
+        fn set_vring_kick(&mut self, queue_index: usize, fd: &EventFd) -> Result<()> {
+            assert_eq!(queue_index, 1);
+            Ok(())
+        }
+
+        fn set_vring_err(&mut self, queue_index: usize, fd: &EventFd) -> Result<()> {
+            assert_eq!(queue_index, 1);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_vring_backend_mut() {
+        let b = RwLock::new(MockBackend {});
+
+        assert_eq!(b.get_features().unwrap(), 0x1);
+        b.set_features(0x1).unwrap();
+        b.set_owner().unwrap();
+        b.reset_owner().unwrap();
+        b.set_mem_table(&[]).unwrap();
+        b.set_log_base(0x100, Some(100)).unwrap();
+        b.set_log_fd(100).unwrap();
+        b.set_vring_num(1, 256).unwrap();
+
+        let config = VringConfigData {
+            queue_max_size: 0x1000,
+            queue_size: 0x2000,
+            flags: 0x0,
+            desc_table_addr: 0x4000,
+            used_ring_addr: 0x5000,
+            avail_ring_addr: 0x6000,
+            log_addr: None,
+        };
+        b.set_vring_addr(1, &config).unwrap();
+
+        b.set_vring_base(1, 2).unwrap();
+        assert_eq!(b.get_vring_base(1).unwrap(), 2);
+
+        let eventfd = EventFd::new(0).unwrap();
+        b.set_vring_call(1, &eventfd).unwrap();
+        b.set_vring_kick(1, &eventfd).unwrap();
+        b.set_vring_err(1, &eventfd).unwrap();
+    }
 
     #[test]
     fn test_vring_config_data() {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -364,7 +364,7 @@ impl<T: VhostBackendMut> VhostBackend for RefCell<T> {
 }
 #[cfg(test)]
 mod tests {
-    use VringConfigData;
+    use super::*;
 
     struct MockBackend {}
 

--- a/src/vhost_kern/vsock.rs
+++ b/src/vhost_kern/vsock.rs
@@ -1,21 +1,22 @@
-// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 //
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-Google file.
 
-//! Kernel-based vsock vhost backend.
+//! Kernel-based vhost-vsock backend.
 
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use super::vhost_binding::{VHOST_VSOCK_SET_GUEST_CID, VHOST_VSOCK_SET_RUNNING};
-use super::{ioctl_result, Error, Result, VhostKernBackend};
 use libc;
 use vm_memory::GuestAddressSpace;
 use vmm_sys_util::ioctl::ioctl_with_ref;
+
+use super::vhost_binding::{VHOST_VSOCK_SET_GUEST_CID, VHOST_VSOCK_SET_RUNNING};
+use super::{ioctl_result, Error, Result, VhostKernBackend};
 
 const VHOST_PATH: &str = "/dev/vhost-vsock";
 
@@ -77,5 +78,108 @@ impl<AS: GuestAddressSpace> VhostKernBackend for Vsock<AS> {
 impl<AS: GuestAddressSpace> AsRawFd for Vsock<AS> {
     fn as_raw_fd(&self) -> RawFd {
         self.fd.as_raw_fd()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
+    use vmm_sys_util::eventfd::EventFd;
+
+    use super::*;
+    use crate::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
+
+    #[test]
+    fn test_vsock_new_device() {
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10_0000)]).unwrap();
+        let vsock = Vsock::new(&m).unwrap();
+
+        assert!(vsock.as_raw_fd() >= 0);
+        assert!(vsock.mem().find_region(GuestAddress(0x100)).is_some());
+        assert!(vsock.mem().find_region(GuestAddress(0x10_0000)).is_none());
+    }
+
+    #[test]
+    fn test_vsock_is_valid() {
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10_0000)]).unwrap();
+        let vsock = Vsock::new(&m).unwrap();
+
+        let mut config = VringConfigData {
+            queue_max_size: 32,
+            queue_size: 32,
+            flags: 0,
+            desc_table_addr: 0x1000,
+            used_ring_addr: 0x2000,
+            avail_ring_addr: 0x3000,
+            log_addr: None,
+        };
+        assert_eq!(vsock.is_valid(&config), true);
+
+        config.queue_size = 0;
+        assert_eq!(vsock.is_valid(&config), false);
+        config.queue_size = 31;
+        assert_eq!(vsock.is_valid(&config), false);
+        config.queue_size = 33;
+        assert_eq!(vsock.is_valid(&config), false);
+    }
+
+    #[test]
+    fn test_vsock_ioctls() {
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10_0000)]).unwrap();
+        let vsock = Vsock::new(&m).unwrap();
+
+        let features = vsock.get_features().unwrap();
+        vsock.set_features(features).unwrap();
+
+        vsock.set_owner().unwrap();
+
+        vsock.set_mem_table(&[]).unwrap_err();
+
+        /*
+        let region = VhostUserMemoryRegionInfo {
+            guest_phys_addr: 0x0,
+            memory_size: 0x10_0000,
+            userspace_addr: 0,
+            mmap_offset: 0,
+            mmap_handle: -1,
+        };
+        vsock.set_mem_table(&[region]).unwrap_err();
+         */
+
+        let region = VhostUserMemoryRegionInfo {
+            guest_phys_addr: 0x0,
+            memory_size: 0x10_0000,
+            userspace_addr: m.get_host_address(GuestAddress(0x0)).unwrap() as u64,
+            mmap_offset: 0,
+            mmap_handle: -1,
+        };
+        vsock.set_mem_table(&[region]).unwrap();
+
+        vsock.set_log_base(0x4000, Some(1)).unwrap_err();
+        vsock.set_log_base(0x4000, None).unwrap();
+
+        let eventfd = EventFd::new(0).unwrap();
+        vsock.set_log_fd(eventfd.as_raw_fd()).unwrap();
+
+        vsock.set_vring_num(0, 32).unwrap();
+
+        let config = VringConfigData {
+            queue_max_size: 32,
+            queue_size: 32,
+            flags: 0,
+            desc_table_addr: 0x1000,
+            used_ring_addr: 0x2000,
+            avail_ring_addr: 0x3000,
+            log_addr: None,
+        };
+        vsock.set_vring_addr(0, &config).unwrap();
+        vsock.set_vring_base(0, 1).unwrap();
+        vsock.set_vring_call(0, &eventfd).unwrap();
+        vsock.set_vring_kick(0, &eventfd).unwrap();
+        vsock.set_vring_err(0, &eventfd).unwrap();
+        assert_eq!(vsock.get_vring_base(0).unwrap(), 1);
+        vsock.set_guest_cid(0xdead).unwrap();
+        //vsock.start().unwrap();
+        //vsock.stop().unwrap();
     }
 }

--- a/src/vhost_kern/vsock.rs
+++ b/src/vhost_kern/vsock.rs
@@ -17,6 +17,7 @@ use vmm_sys_util::ioctl::ioctl_with_ref;
 
 use super::vhost_binding::{VHOST_VSOCK_SET_GUEST_CID, VHOST_VSOCK_SET_RUNNING};
 use super::{ioctl_result, Error, Result, VhostKernBackend};
+use crate::vsock::VhostVsock;
 
 const VHOST_PATH: &str = "/dev/vhost-vsock";
 
@@ -40,30 +41,25 @@ impl<AS: GuestAddressSpace> Vsock<AS> {
         })
     }
 
-    /// Set the CID for the guest.  This number is used for routing all data destined for
-    /// running in the guest. Each guest on a hypervisor must have an unique CID
-    ///
-    /// # Arguments
-    /// * `cid` - CID to assign to the guest
-    pub fn set_guest_cid(&self, cid: u64) -> Result<()> {
-        let ret = unsafe { ioctl_with_ref(&self.fd, VHOST_VSOCK_SET_GUEST_CID(), &cid) };
-        ioctl_result(ret, ())
-    }
-
-    /// Tell the VHOST driver to start performing data transfer.
-    pub fn start(&self) -> Result<()> {
-        self.set_running(true)
-    }
-
-    /// Tell the VHOST driver to stop performing data transfer.
-    pub fn stop(&self) -> Result<()> {
-        self.set_running(false)
-    }
-
     fn set_running(&self, running: bool) -> Result<()> {
         let on: ::std::os::raw::c_int = if running { 1 } else { 0 };
         let ret = unsafe { ioctl_with_ref(&self.fd, VHOST_VSOCK_SET_RUNNING(), &on) };
         ioctl_result(ret, ())
+    }
+}
+
+impl<AS: GuestAddressSpace> VhostVsock for Vsock<AS> {
+    fn set_guest_cid(&self, cid: u64) -> Result<()> {
+        let ret = unsafe { ioctl_with_ref(&self.fd, VHOST_VSOCK_SET_GUEST_CID(), &cid) };
+        ioctl_result(ret, ())
+    }
+
+    fn start(&self) -> Result<()> {
+        self.set_running(true)
+    }
+
+    fn stop(&self) -> Result<()> {
+        self.set_running(false)
     }
 }
 

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn test_set_owner() {
         let slave_be = Arc::new(Mutex::new(DummySlaveReqHandler::new()));
-        let (mut master, mut slave) =
+        let (master, mut slave) =
             create_slave("/tmp/vhost_user_lib_unit_test_owner", slave_be.clone());
 
         assert_eq!(slave_be.lock().unwrap().owned, false);

--- a/src/vsock.rs
+++ b/src/vsock.rs
@@ -20,11 +20,11 @@ pub trait VhostVsock: VhostBackend {
     ///
     /// # Arguments
     /// * `cid` - CID to assign to the guest
-    fn set_guest_cid(&mut self, cid: u64) -> Result<()>;
+    fn set_guest_cid(&self, cid: u64) -> Result<()>;
 
     /// Tell the VHOST driver to start performing data transfer.
-    fn start(&mut self) -> Result<()>;
+    fn start(&self) -> Result<()>;
 
     /// Tell the VHOST driver to stop performing data transfer.
-    fn stop(&mut self) -> Result<()>;
+    fn stop(&self) -> Result<()>;
 }


### PR DESCRIPTION
This PR prepares for publishing to crates.io by polishing vhost-kern related code:
1) introduce trait VhostBackendMut
2) add more unit tests for vhost-kern
3) improve vhost-kern/vsock