### PR TITLE
Loosen reply ack

### DIFF
--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -777,7 +777,6 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         let vflag = VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
         let pflag = VhostUserProtocolFeatures::REPLY_ACK;
         if (self.virtio_features & vflag) != 0
-            && (self.acked_virtio_features & vflag) != 0
             && self.protocol_features.contains(pflag)
             && (self.acked_protocol_features & pflag.bits()) != 0
         {


### PR DESCRIPTION
This fixes a problem I came across with QEMU and vhost.rs having slightly different ideas about when replies should be handled. We could probably do more to detect mismatches between the reply needed field and the negotiated state of the protocol.