### PR TITLE
vhost_user: Add support for VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 81.3, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 81.2, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_user/dummy_slave.rs
+++ b/src/vhost_user/dummy_slave.rs
@@ -8,6 +8,7 @@ use super::*;
 
 pub const MAX_QUEUE_NUM: usize = 2;
 pub const MAX_VRING_NUM: usize = 256;
+pub const MAX_MEM_SLOTS: usize = 32;
 pub const VIRTIO_FEATURES: u64 = 0x40000003;
 
 #[derive(Default)]
@@ -242,5 +243,9 @@ impl VhostUserSlaveReqHandlerMut for DummySlaveReqHandler {
             return Err(Error::InvalidParam);
         }
         Ok(())
+    }
+
+    fn get_max_mem_slots(&mut self) -> Result<u64> {
+        Ok(MAX_MEM_SLOTS as u64)
     }
 }

--- a/src/vhost_user/dummy_slave.rs
+++ b/src/vhost_user/dummy_slave.rs
@@ -248,4 +248,8 @@ impl VhostUserSlaveReqHandlerMut for DummySlaveReqHandler {
     fn get_max_mem_slots(&mut self) -> Result<u64> {
         Ok(MAX_MEM_SLOTS as u64)
     }
+
+    fn add_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion, _fd: RawFd) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/vhost_user/dummy_slave.rs
+++ b/src/vhost_user/dummy_slave.rs
@@ -252,4 +252,8 @@ impl VhostUserSlaveReqHandlerMut for DummySlaveReqHandler {
     fn add_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion, _fd: RawFd) -> Result<()> {
         Ok(())
     }
+
+    fn remove_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -56,6 +56,9 @@ pub trait VhostUserMaster: VhostBackend {
 
     /// Add a new guest memory mapping for vhost to use.
     fn add_mem_region(&mut self, region: &VhostUserMemoryRegionInfo) -> Result<()>;
+
+    /// Remove a guest memory mapping from vhost.
+    fn remove_mem_region(&mut self, region: &VhostUserMemoryRegionInfo) -> Result<()>;
 }
 
 fn error_code<T>(err: VhostUserError) -> Result<T> {
@@ -473,6 +476,26 @@ impl VhostUserMaster for Master {
         );
         let fds = [region.mmap_handle];
         let hdr = node.send_request_with_body(MasterReq::ADD_MEM_REG, &body, Some(&fds))?;
+        node.wait_for_ack(&hdr).map_err(|e| e.into())
+    }
+
+    fn remove_mem_region(&mut self, region: &VhostUserMemoryRegionInfo) -> Result<()> {
+        let mut node = self.node();
+        if node.acked_protocol_features & VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS.bits() == 0
+        {
+            return error_code(VhostUserError::InvalidOperation);
+        }
+        if region.memory_size == 0 {
+            return error_code(VhostUserError::InvalidParam);
+        }
+
+        let body = VhostUserSingleMemoryRegion::new(
+            region.guest_phys_addr,
+            region.memory_size,
+            region.userspace_addr,
+            region.mmap_offset,
+        );
+        let hdr = node.send_request_with_body(MasterReq::REM_MEM_REG, &body, None)?;
         node.wait_for_ack(&hdr).map_err(|e| e.into())
     }
 }

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -479,6 +479,49 @@ impl VhostUserMsgValidator for VhostUserMemoryRegion {
 /// Payload of the VhostUserMemory message.
 pub type VhostUserMemoryPayload = Vec<VhostUserMemoryRegion>;
 
+/// Single memory region descriptor as payload for ADD_MEM_REG and REM_MEM_REG
+/// requests.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct VhostUserSingleMemoryRegion {
+    /// Padding for correct alignment
+    padding: u64,
+    /// Guest physical address of the memory region.
+    pub guest_phys_addr: u64,
+    /// Size of the memory region.
+    pub memory_size: u64,
+    /// Virtual address in the current process.
+    pub user_addr: u64,
+    /// Offset where region starts in the mapped memory.
+    pub mmap_offset: u64,
+}
+
+impl VhostUserSingleMemoryRegion {
+    /// Create a new instance.
+    pub fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
+        VhostUserSingleMemoryRegion {
+            padding: 0,
+            guest_phys_addr,
+            memory_size,
+            user_addr,
+            mmap_offset,
+        }
+    }
+}
+
+impl VhostUserMsgValidator for VhostUserSingleMemoryRegion {
+    fn is_valid(&self) -> bool {
+        if self.memory_size == 0
+            || self.guest_phys_addr.checked_add(self.memory_size).is_none()
+            || self.user_addr.checked_add(self.memory_size).is_none()
+            || self.mmap_offset.checked_add(self.memory_size).is_none()
+        {
+            return false;
+        }
+        true
+    }
+}
+
 /// Vring state descriptor.
 #[repr(packed)]
 #[derive(Default)]

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -114,10 +114,30 @@ pub enum MasterReq {
     POSTCOPY_END = 30,
     /// Get a shared buffer from slave.
     GET_INFLIGHT_FD = 31,
-    /// Send the shared inflight buffer back to slave
+    /// Send the shared inflight buffer back to slave.
     SET_INFLIGHT_FD = 32,
+    /// Sets the GPU protocol socket file descriptor.
+    GPU_SET_SOCKET = 33,
+    /// Ask the vhost user backend to disable all rings and reset all internal
+    /// device state to the initial state.
+    RESET_DEVICE = 34,
+    /// Indicate that a buffer was added to the vring instead of signalling it
+    /// using the vring’s kick file descriptor.
+    VRING_KICK = 35,
+    /// Return a u64 payload containing the maximum number of memory slots.
+    GET_MAX_MEM_SLOTS = 36,
+    /// Update the memory tables by adding the region described.
+    ADD_MEM_REG = 37,
+    /// Update the memory tables by removing the region described.
+    REM_MEM_REG = 38,
+    /// Notify the backend with updated device status as defined in the VIRTIO
+    /// specification.
+    SET_STATUS = 39,
+    /// Query the backend for its device status as defined in the VIRTIO
+    /// specification.
+    GET_STATUS = 40,
     /// Upper bound of valid commands.
-    MAX_CMD = 33,
+    MAX_CMD = 41,
 }
 
 impl Into<u32> for MasterReq {

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -333,6 +333,9 @@ mod tests {
             slave.handle_request().unwrap();
             slave.handle_request().unwrap();
 
+            // get_max_mem_slots()
+            slave.handle_request().unwrap();
+
             sbar.wait();
         });
 
@@ -394,6 +397,9 @@ mod tests {
         master.set_vring_call(0, &eventfd).unwrap();
         master.set_vring_kick(0, &eventfd).unwrap();
         master.set_vring_err(0, &eventfd).unwrap();
+
+        let max_mem_slots = master.get_max_mem_slots().unwrap();
+        assert_eq!(max_mem_slots, 32);
 
         mbar.wait();
     }

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -341,6 +341,9 @@ mod tests {
             // add_mem_region()
             slave.handle_request().unwrap();
 
+            // remove_mem_region()
+            slave.handle_request().unwrap();
+
             sbar.wait();
         });
 
@@ -415,6 +418,8 @@ mod tests {
             mmap_handle: region_file.as_raw_fd(),
         };
         master.add_mem_region(&region).unwrap();
+
+        master.remove_mem_region(&region).unwrap();
 
         mbar.wait();
     }


### PR DESCRIPTION
This PR introduces the support for recently added message types `VHOST_USER_GET_MAX_MEM_SLOTS`, `VHOST_USER_ADD_MEM_REG` and `VHOST_USER_REM_MEM_REG`, coming from the latest `vhost-user` specification, and gated by the protocol feature `VHOST_USER_PROTOCOL_F_CONFIGURE_MEM_SLOTS`.

They are specifically designed for memory hotplug and memory hot-unplug. They are more efficient than using `VHOST_USER_SET_MEM_TABLE` as the backend does not need to remap all regions if a single region is added or removed.
For the particular case of adding new regions, `VHOST_USER_ADD_MEM_REG` overcome the limitation of 8 regions coming from `VHOST_USER_SET_MEM_TABLE`.