### PR TITLE
vhost_user: config offset matches qemu

### DIFF
--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -874,10 +874,14 @@ mod tests {
         }
 
         master
-            .set_config(0x100, VhostUserConfigFlags::WRITABLE, &buf[0..4])
+            .set_config(0, VhostUserConfigFlags::WRITABLE, &buf[0..4])
             .unwrap();
         master
-            .set_config(0x0, VhostUserConfigFlags::WRITABLE, &buf[0..4])
+            .set_config(
+                VHOST_USER_CONFIG_SIZE,
+                VhostUserConfigFlags::WRITABLE,
+                &buf[0..4],
+            )
             .unwrap_err();
         master
             .set_config(0x1000, VhostUserConfigFlags::WRITABLE, &buf[0..4])
@@ -890,10 +894,10 @@ mod tests {
             )
             .unwrap_err();
         master
-            .set_config(0x100, VhostUserConfigFlags::WRITABLE, &buf)
+            .set_config(VHOST_USER_CONFIG_SIZE, VhostUserConfigFlags::WRITABLE, &buf)
             .unwrap_err();
         master
-            .set_config(0x100, VhostUserConfigFlags::WRITABLE, &[])
+            .set_config(VHOST_USER_CONFIG_SIZE, VhostUserConfigFlags::WRITABLE, &[])
             .unwrap_err();
     }
 


### PR DESCRIPTION
Modify the interpretation of the set and get config offset field to
match qemu. The wording in the vhost user spec is ambiguous, bet lets
defer to qemu's implementation so vhost based devices can be used with
qemu as a VMM. Fixes #29.

Signed-off-by: Dylan Reid <dgreid@chromium.org>