### PR TITLE
vhost_user: Fix check for SET_VRING_ENABLE

### DIFF
--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -400,8 +400,8 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
             }
             MasterReq::SET_VRING_ENABLE => {
                 let msg = self.extract_request_body::<VhostUserVringState>(&hdr, size, &buf)?;
-                if self.acked_protocol_features & VhostUserProtocolFeatures::MQ.bits() == 0
-                    && msg.index > 0
+                if self.acked_virtio_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+                    == 0
                 {
                     return Err(Error::InvalidOperation);
                 }


### PR DESCRIPTION
We should allow to receive SET_VRING_ENABLE request with non-zero index even if
MQ protocol feature is disabled because some device can have multiple queues
without the MQ feature.
e.g. virtio-net means that it supports multiple pairs of tx/rx queues. So, the
slave must support at least one pair of queues regardless of whether MQ is
supported.