### PR TITLE
vhost_user: Make Endpoint public

### DIFF
--- a/src/vhost_user/connection.rs
+++ b/src/vhost_user/connection.rs
@@ -89,7 +89,7 @@ impl Drop for Listener {
 }
 
 /// Unix domain socket endpoint for vhost-user connection.
-pub(super) struct Endpoint<R: Req> {
+pub struct Endpoint<R: Req> {
     sock: UnixStream,
     _r: PhantomData<R>,
 }

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -23,7 +23,7 @@ use std::io::Error as IOError;
 pub mod message;
 
 mod connection;
-pub use self::connection::Listener;
+pub use self::connection::{Endpoint, Listener};
 
 #[cfg(feature = "vhost-user-master")]
 mod master;


### PR DESCRIPTION
Exposing Endpoint structure allows for crate's consumers to manage the
vhost-user connection on their own. This is particularly useful for
implementing a vhost-user backend running as a client while the VMM is
the server side of the connection.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>