### PR TITLE
vhost_user: Fix wrong behavior for get/set protocol features

### DIFF
--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -317,7 +317,7 @@ impl VhostUserMaster for Master {
     fn get_protocol_features(&mut self) -> Result<VhostUserProtocolFeatures> {
         let mut node = self.node();
         let flag = VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
-        if node.virtio_features & flag == 0 || node.acked_virtio_features & flag == 0 {
+        if node.virtio_features & flag == 0 {
             return error_code(VhostUserError::InvalidOperation);
         }
         let hdr = node.send_request_header(MasterReq::GET_PROTOCOL_FEATURES, None)?;
@@ -334,7 +334,7 @@ impl VhostUserMaster for Master {
     fn set_protocol_features(&mut self, features: VhostUserProtocolFeatures) -> Result<()> {
         let mut node = self.node();
         let flag = VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
-        if node.virtio_features & flag == 0 || node.acked_virtio_features & flag == 0 {
+        if node.virtio_features & flag == 0 {
             return error_code(VhostUserError::InvalidOperation);
         }
         let val = VhostUserU64::new(features.bits());


### PR DESCRIPTION
Based on the specification, one can call into
VHOST_USER_GET_PROTOCOL_FEATURES or VHOST_USER_SET_PROTOCOL_FEATURES
before VHOST_USER_SET_FEATURES.

The current code is wrong as it expects the VIRTIO features to be
already acknowledged at the time the protocol features are get/set.

Quote from the spec for both VHOST_USER_GET_PROTOCOL_FEATURES and
VHOST_USER_SET_PROTOCOL_FEATURES:

    Slave that reported VHOST_USER_F_PROTOCOL_FEATURES must support this
    message even before VHOST_USER_SET_FEATURES was called.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>