### PR TITLE
vhost_user: Add header flags support

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 81.2, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 81.0, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}


### PR DESCRIPTION
Introduce a new method set_flags() in order to let the caller define the
expected set of flags that should be applied to the header for the
following messages.

Fixes #40

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>