### PR TITLE
vhost_user: Add Inflight I/O tracking support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ vmm-sys-util = ">=0.3.1"
 vm-memory = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
+tempfile = ">=3.2.0"
 vm-memory = { version = "0.2.0", features=["backend-mmap"] }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 81.0, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 80.9, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -673,6 +673,42 @@ impl VhostUserMsgValidator for VhostUserConfig {
 /// Payload for the VhostUserConfig message.
 pub type VhostUserConfigPayload = Vec<u8>;
 
+/// Single memory region descriptor as payload for ADD_MEM_REG and REM_MEM_REG
+/// requests.
+#[repr(C)]
+#[derive(Default, Clone)]
+pub struct VhostUserInflight {
+    /// Size of the area to track inflight I/O.
+    pub mmap_size: u64,
+    /// Offset of this area from the start of the supplied file descriptor.
+    pub mmap_offset: u64,
+    /// Number of virtqueues.
+    pub num_queues: u16,
+    /// Size of virtqueues.
+    pub queue_size: u16,
+}
+
+impl VhostUserInflight {
+    /// Create a new instance.
+    pub fn new(mmap_size: u64, mmap_offset: u64, num_queues: u16, queue_size: u16) -> Self {
+        VhostUserInflight {
+            mmap_size,
+            mmap_offset,
+            num_queues,
+            queue_size,
+        }
+    }
+}
+
+impl VhostUserMsgValidator for VhostUserInflight {
+    fn is_valid(&self) -> bool {
+        if self.num_queues == 0 || self.queue_size == 0 {
+            return false;
+        }
+        true
+    }
+}
+
 /*
  * TODO: support dirty log, live migration and IOTLB operations.
 #[repr(packed)]

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -307,6 +307,11 @@ mod tests {
                 VhostUserProtocolFeatures::all().bits()
             );
 
+            // get_inflight_fd()
+            slave.handle_request().unwrap();
+            // set_inflight_fd()
+            slave.handle_request().unwrap();
+
             // get_queue_num()
             slave.handle_request().unwrap();
 
@@ -358,6 +363,19 @@ mod tests {
         let features = master.get_protocol_features().unwrap();
         assert_eq!(features.bits(), VhostUserProtocolFeatures::all().bits());
         master.set_protocol_features(features).unwrap();
+
+        // Retrieve inflight I/O tracking information
+        let (inflight_info, inflight_file) = master
+            .get_inflight_fd(&VhostUserInflight {
+                num_queues: 2,
+                queue_size: 256,
+                ..Default::default()
+            })
+            .unwrap();
+        // Set the buffer back to the backend
+        master
+            .set_inflight_fd(&inflight_info, inflight_file.as_raw_fd())
+            .unwrap();
 
         let num = master.get_queue_num().unwrap();
         assert_eq!(num, 2);


### PR DESCRIPTION
The inflight I/O tracking feature is useful for handling crashes and
disconnections from the backend. It allows the backend to rely on a
buffer that was shared earlier with the VMM to restore to the previous
state it was before the crash.

This feature depends on the availability of the protocol feature
VHOST_USER_PROTOCOL_F_INFLIGHT_SHMFD, and it implements both
VHOST_USER_GET_INFLIGHT_FD and VHOST_USER_SET_INFLIGHT_FD messages.

Fixes #43

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>