### PR TITLE
Add SlaveReqHandler::from_stream

### DIFF
--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -269,6 +269,11 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         }
     }
 
+    /// Create a vhost-user slave endpoint from a connected socket.
+    pub fn from_stream(socket: UnixStream, backend: Arc<S>) -> Self {
+        Self::new(Endpoint::from_stream(socket), backend)
+    }
+
     /// Create a new vhost-user slave endpoint.
     ///
     /// # Arguments


### PR DESCRIPTION
A device process may already have a connected socket to the VMM, for
example by inheriting one end of a socketpair() created by the parent
process.  Add a method to create a SlaveReqHandler directly from a
connected socket.