### PR TITLE
bump rust-vmm-ci with manual fixes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,5 +13,5 @@ steps:
     os: linux
    plugins:
     - docker#v3.0.1:
-       image: "rustvmm/dev:v11"
+       image: "rustvmm/dev:v12"
        always-pull: true

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 80.9, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 82.7, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -7,6 +7,7 @@
 
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
+#![allow(clippy::upper_case_acronyms)]
 
 use std::fmt::Debug;
 use std::marker::PhantomData;


### PR DESCRIPTION
Allow enum names whose characters are all upper case such as `NOOP`.
This change is needed to uprev bump rust-vmm-ci's version at #46.

Signed-off-by: Keiichi Watanabe <keiichiw@chromium.org>