### PR TITLE
Inflight io: Define queue regions for split and packed virtqueues

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 83.6, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 82.8, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -837,6 +837,95 @@ impl QueueRegionSplit {
     }
 }
 
+/// Inflight I/O descriptor state for packed virtqueues
+#[repr(packed)]
+#[derive(Clone, Copy)]
+struct DescStatePacked {
+    /// Indicate whether this descriptor (only head) is inflight or not.
+    inflight: u8,
+    /// Padding
+    padding: u8,
+    /// Link to next free entry
+    next: u16,
+    /// Link to last entry of descriptor list, only for head
+    last: u16,
+    /// Length of descriptor list, only for head
+    num: u16,
+    /// Preserve order of fetching avail descriptors, only for head
+    counter: u64,
+    /// Buffer ID
+    id: u16,
+    /// Descriptor flags
+    flags: u16,
+    /// Buffer length
+    len: u32,
+    /// Buffer address
+    addr: u64,
+}
+
+impl DescStatePacked {
+    fn new() -> Self {
+        DescStatePacked {
+            inflight: 0,
+            padding: 0,
+            next: 0,
+            last: 0,
+            num: 0,
+            counter: 0,
+            id: 0,
+            flags: 0,
+            len: 0,
+            addr: 0,
+        }
+    }
+}
+
+/// Inflight I/O queue region for packed virtqueues
+#[allow(safe_packed_borrows)]
+#[repr(packed)]
+struct QueueRegionPacked {
+    /// Features flags of this region
+    features: u64,
+    /// version of this region
+    version: u16,
+    /// size of descriptor state array
+    desc_num: u16,
+    /// head of free DescStatePacked entry list
+    free_head: u16,
+    /// old head of free DescStatePacked entry list
+    old_free_head: u16,
+    /// used idx of descriptor ring
+    used_idx: u16,
+    /// old used idx of descriptor ring
+    old_used_idx: u16,
+    /// device ring wrap counter
+    used_wrap_counter: u8,
+    /// old device ring wrap counter
+    old_used_wrap_counter: u8,
+    /// Padding
+    padding: [u8; 7],
+    /// Pointer to array tracking state of each descriptor from descriptor ring
+    desc: u64,
+}
+
+impl QueueRegionPacked {
+    fn new(features: u64, queue_size: u16) -> Self {
+        QueueRegionPacked {
+            features,
+            version: 1,
+            desc_num: queue_size,
+            free_head: 0,
+            old_free_head: 0,
+            used_idx: 0,
+            old_used_idx: 0,
+            used_wrap_counter: 0,
+            old_used_wrap_counter: 0,
+            padding: [0; 7],
+            desc: 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
These set of commits introduce the queue region and descriptor state structures needed to manage inflight I/O tracking.