### PR TITLE
vhost_user: Move utility function to mod.rs

### DIFF
--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -14,8 +14,7 @@ use vmm_sys_util::eventfd::EventFd;
 
 use super::connection::Endpoint;
 use super::message::*;
-use super::slave_req_handler::take_single_file;
-use super::{Error as VhostUserError, Result as VhostUserResult};
+use super::{take_single_file, Error as VhostUserError, Result as VhostUserResult};
 use crate::backend::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use crate::{Error, Result};
 

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -18,6 +18,7 @@
 //! Most messages that can be sent via the Unix domain socket implementing vhost-user have an
 //! equivalent ioctl to the kernel implementation.
 
+use std::fs::File;
 use std::io::Error as IOError;
 
 pub mod message;
@@ -174,6 +175,16 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Result of request handler.
 pub type HandlerResult<T> = std::result::Result<T, IOError>;
+
+/// Utility function to take the first element from option of a vector of files.
+/// Returns `None` if the vector contains no file or more than one file.
+pub(crate) fn take_single_file(files: Option<Vec<File>>) -> Option<File> {
+    let mut files = files?;
+    if files.len() != 1 {
+        return None;
+    }
+    Some(files.swap_remove(0))
+}
 
 #[cfg(all(test, feature = "vhost-user-slave"))]
 mod dummy_slave;

--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use super::connection::Endpoint;
 use super::message::*;
 use super::slave_fs_cache::SlaveFsCacheReq;
-use super::{Error, Result};
+use super::{take_single_file, Error, Result};
 
 /// Services provided to the master by the slave with interior mutability.
 ///
@@ -801,16 +801,6 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
             .send_message_with_payload(&hdr, msg, payload, None)?;
         Ok(())
     }
-}
-
-/// Utility function to take the first element from option of a vector of files.
-/// Returns `None` if the vector contains no file or more than one file.
-pub(crate) fn take_single_file(files: Option<Vec<File>>) -> Option<File> {
-    let mut files = files?;
-    if files.len() != 1 {
-        return None;
-    }
-    Some(files.swap_remove(0))
 }
 
 impl<S: VhostUserSlaveReqHandler> AsRawFd for SlaveReqHandler<S> {


### PR DESCRIPTION
Move take_single_file() to mod.rs as it is used in both master feature
and slave feature so that we can build the master feature without the
slave feature.

Signed-off-by: Keiichi Watanabe <keiichiw@chromium.org>