### PR TITLE
Inflight I/O: Make structs and members public

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 82.8, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 82.2, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -783,8 +783,8 @@ impl VhostUserMsgValidator for VhostUserFSSlaveMsg {
 
 /// Inflight I/O descriptor state for split virtqueues
 #[repr(packed)]
-#[derive(Clone, Copy)]
-struct DescStateSplit {
+#[derive(Clone, Copy, Default)]
+pub struct DescStateSplit {
     /// Indicate whether this descriptor (only head) is inflight or not.
     inflight: u8,
     /// Padding
@@ -796,20 +796,16 @@ struct DescStateSplit {
 }
 
 impl DescStateSplit {
-    fn new() -> Self {
-        DescStateSplit {
-            inflight: 0,
-            padding: [0; 5],
-            next: 0,
-            counter: 0,
-        }
+    /// New instance of DescStateSplit struct
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 
 /// Inflight I/O queue region for split virtqueues
 #[allow(safe_packed_borrows)]
 #[repr(packed)]
-struct QueueRegionSplit {
+pub struct QueueRegionSplit {
     /// Features flags of this region
     features: u64,
     /// Version of this region
@@ -825,7 +821,8 @@ struct QueueRegionSplit {
 }
 
 impl QueueRegionSplit {
-    fn new(features: u64, queue_size: u16) -> Self {
+    /// New instance of QueueRegionSplit struct
+    pub fn new(features: u64, queue_size: u16) -> Self {
         QueueRegionSplit {
             features,
             version: 1,
@@ -839,8 +836,8 @@ impl QueueRegionSplit {
 
 /// Inflight I/O descriptor state for packed virtqueues
 #[repr(packed)]
-#[derive(Clone, Copy)]
-struct DescStatePacked {
+#[derive(Clone, Copy, Default)]
+pub struct DescStatePacked {
     /// Indicate whether this descriptor (only head) is inflight or not.
     inflight: u8,
     /// Padding
@@ -864,26 +861,16 @@ struct DescStatePacked {
 }
 
 impl DescStatePacked {
-    fn new() -> Self {
-        DescStatePacked {
-            inflight: 0,
-            padding: 0,
-            next: 0,
-            last: 0,
-            num: 0,
-            counter: 0,
-            id: 0,
-            flags: 0,
-            len: 0,
-            addr: 0,
-        }
+    /// New instance of DescStatePacked struct
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 
 /// Inflight I/O queue region for packed virtqueues
 #[allow(safe_packed_borrows)]
 #[repr(packed)]
-struct QueueRegionPacked {
+pub struct QueueRegionPacked {
     /// Features flags of this region
     features: u64,
     /// version of this region
@@ -909,7 +896,8 @@ struct QueueRegionPacked {
 }
 
 impl QueueRegionPacked {
-    fn new(features: u64, queue_size: u16) -> Self {
+    /// New instance of QueueRegionPacked struct
+    pub fn new(features: u64, queue_size: u16) -> Self {
         QueueRegionPacked {
             features,
             version: 1,


### PR DESCRIPTION
The queue region and descriptor state structs introduced in the previous commits need to be public to be used by other crates.