### PR TITLE
fix `warning: reference to packed field is unaligned`

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 82.2, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 82.3, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}


### PR DESCRIPTION
fix warning, when compiling with 1.53.0
```
warning: reference to packed field is unaligned
   --> src/vhost_user/message.rs:252:53
    |
252 |         unsafe { std::mem::transmute_copy::<u32, R>(&self.request) }
    |                                                     ^^^^^^^^^^^^^
    |
    = note: `#[warn(unaligned_references)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
```

Signed-off-by: wanglei <wllenyj@linux.alibaba.com>