### PR TITLE
update vm-memory requirement from 0.2.0 to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ bitflags = ">=1.0.1"
 libc = ">=0.2.39"
 
 vmm-sys-util = ">=0.3.1"
-vm-memory = { version = "0.2.0", optional = true }
+vm-memory = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 tempfile = ">=3.2.0"
-vm-memory = { version = "0.2.0", features=["backend-mmap"] }
+vm-memory = { version = "0.5.0", features=["backend-mmap"] }


### PR DESCRIPTION
build(deps): update vm-memory requirement from 0.2.0 to 0.5.0
Updates the requirements on
[vm-memory](https://github.com/rust-vmm/vm-memory) to permit the latest
version.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>