### PR TITLE
Fix set_log_base() implementation for vhost-user

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 81.9, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 81.3, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_kern/mod.rs
+++ b/src/vhost_kern/mod.rs
@@ -18,8 +18,8 @@ use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref};
 
 use super::{
-    Error, Result, VhostBackend, VhostUserMemoryRegionInfo, VringConfigData,
-    VHOST_MAX_MEMORY_REGIONS,
+    Error, Result, VhostBackend, VhostUserDirtyLogRegion, VhostUserMemoryRegionInfo,
+    VringConfigData, VHOST_MAX_MEMORY_REGIONS,
 };
 
 pub mod vhost_binding;
@@ -146,8 +146,8 @@ impl<T: VhostKernBackend> VhostBackend for T {
     ///
     /// # Arguments
     /// * `base` - Base address for page modification logging.
-    fn set_log_base(&self, base: u64, fd: Option<RawFd>) -> Result<()> {
-        if fd.is_some() {
+    fn set_log_base(&self, base: u64, region: Option<VhostUserDirtyLogRegion>) -> Result<()> {
+        if region.is_some() {
             return Err(Error::LogAddress);
         }
 

--- a/src/vhost_kern/vsock.rs
+++ b/src/vhost_kern/vsock.rs
@@ -82,7 +82,9 @@ mod tests {
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;
-    use crate::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
+    use crate::{
+        VhostBackend, VhostUserDirtyLogRegion, VhostUserMemoryRegionInfo, VringConfigData,
+    };
 
     #[test]
     fn test_vsock_new_device() {
@@ -150,7 +152,16 @@ mod tests {
         };
         vsock.set_mem_table(&[region]).unwrap();
 
-        vsock.set_log_base(0x4000, Some(1)).unwrap_err();
+        vsock
+            .set_log_base(
+                0x4000,
+                Some(VhostUserDirtyLogRegion {
+                    mmap_size: 0x1000,
+                    mmap_offset: 0x10,
+                    mmap_handle: 1,
+                }),
+            )
+            .unwrap_err();
         vsock.set_log_base(0x4000, None).unwrap();
 
         let eventfd = EventFd::new(0).unwrap();

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -731,6 +731,35 @@ impl VhostUserMsgValidator for VhostUserInflight {
     }
 }
 
+/// Single memory region descriptor as payload for SET_LOG_BASE request.
+#[repr(C)]
+#[derive(Default, Clone)]
+pub struct VhostUserLog {
+    /// Size of the area to log dirty pages.
+    pub mmap_size: u64,
+    /// Offset of this area from the start of the supplied file descriptor.
+    pub mmap_offset: u64,
+}
+
+impl VhostUserLog {
+    /// Create a new instance.
+    pub fn new(mmap_size: u64, mmap_offset: u64) -> Self {
+        VhostUserLog {
+            mmap_size,
+            mmap_offset,
+        }
+    }
+}
+
+impl VhostUserMsgValidator for VhostUserLog {
+    fn is_valid(&self) -> bool {
+        if self.mmap_size == 0 || self.mmap_offset.checked_add(self.mmap_size).is_none() {
+            return false;
+        }
+        true
+    }
+}
+
 /*
  * TODO: support dirty log, live migration and IOTLB operations.
 #[repr(packed)]

--- a/src/vhost_user/mod.rs
+++ b/src/vhost_user/mod.rs
@@ -203,7 +203,7 @@ mod tests {
     use super::message::*;
     use super::*;
     use crate::backend::VhostBackend;
-    use crate::{VhostUserMemoryRegionInfo, VringConfigData};
+    use crate::{VhostUserDirtyLogRegion, VhostUserMemoryRegionInfo, VringConfigData};
 
     fn temp_path() -> PathBuf {
         PathBuf::from(format!(
@@ -415,8 +415,16 @@ mod tests {
         master.set_slave_request_fd(&eventfd).unwrap();
         master.set_vring_enable(0, true).unwrap();
 
-        // unimplemented yet
-        master.set_log_base(0, Some(eventfd.as_raw_fd())).unwrap();
+        master
+            .set_log_base(
+                0,
+                Some(VhostUserDirtyLogRegion {
+                    mmap_size: 0x1000,
+                    mmap_offset: 0,
+                    mmap_handle: eventfd.as_raw_fd(),
+                }),
+            )
+            .unwrap();
         master.set_log_fd(eventfd.as_raw_fd()).unwrap();
 
         master.set_vring_num(0, 256).unwrap();


### PR DESCRIPTION
The SET_LOG_BASE implementation was incomplete as it didn't include the
ability to send the shared memory region information along with the file
descriptor.

This is required to perform proper dirty page logging with a vhost-user
device.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>