### PR TITLE
Derive Default, Clone and Copy for VringConfigData

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 82.3, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 81.9, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -21,6 +21,7 @@ use super::Result;
 pub const VHOST_MAX_MEMORY_REGIONS: usize = 255;
 
 /// Vring configuration data.
+#[derive(Default, Clone, Copy)]
 pub struct VringConfigData {
     /// Maximum queue size supported by the driver.
     pub queue_max_size: u16,


### PR DESCRIPTION
It is helpful for the consumer of this crate to be able clone and copy
the VringConfigData structure, as well as being able to initialize it
only partially thanks to the Default trait.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>