### PR TITLE
vhost_user: fix struct name in Debug impl

### DIFF
--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -234,7 +234,7 @@ pub(super) struct VhostUserMsgHeader<R: Req> {
 
 impl<R: Req> Debug for VhostUserMsgHeader<R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Point")
+        f.debug_struct("VhostUserMsgHeader")
             .field("request", &{ self.request })
             .field("flags", &{ self.flags })
             .field("size", &{ self.size })


### PR DESCRIPTION
I think this might have been a remnant of the example in the fmt
documentation![1]

[1]: https://doc.rust-lang.org/stable/core/fmt/trait.Debug.html#examples

Signed-off-by: Alyssa Ross <hi@alyssa.is>
