### PR TITLE
Fix an error in license statement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Liu Jiang <gerry@linux.alibaba.com>"]
 repository = "https://github.com/rust-vmm/vhost"
 documentation = "https://docs.rs/vhost"
 readme = "README.md"
-license = "Apache-2.0 or BSD-3-Clause"
+license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
"Apache-2.0 or BSD-3-Clause" is not an valid license statement and is
rejected by cargo. So change it to "Apache-2.0 OR BSD-3-Clause".

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>