### PR TITLE
vhost_user: handle recv_with_fds being unsafe

### DIFF
--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -43,7 +43,7 @@ pub const VHOST_USER_CONFIG_SIZE: u32 = 0x1000;
 pub const VHOST_USER_MAX_VRINGS: u64 = 0x8000u64;
 
 pub(super) trait Req:
-    Clone + Copy + Debug + PartialEq + Eq + PartialOrd + Ord + Into<u32>
+    Clone + Copy + Debug + PartialEq + Eq + PartialOrd + Ord + Send + Sync + Into<u32>
 {
     fn is_valid(&self) -> bool;
 }
@@ -345,6 +345,8 @@ impl<R: Req> Default for VhostUserMsgHeader<R> {
         }
     }
 }
+
+unsafe impl<R: Req> ByteValued for VhostUserMsgHeader<R> {}
 
 impl<T: Req> VhostUserMsgValidator for VhostUserMsgHeader<T> {
     #[allow(clippy::if_same_then_else)]


### PR DESCRIPTION
`recv_with_fds` from vmm-sys-util was never safe, but was incorrectly not marked as safe.  Handle it safely in every function where we have enough information to know that calling it will be safe, and propogate the unsafe to any function where we don't.

Fortunately this is quite straightforward now all of the high-level methods have the guarantee that they're returning `ByteValued` types.

Signed-off-by: Alyssa Ross <hi@alyssa.is>

***

This change is necessitated by https://github.com/rust-vmm/vmm-sys-util/pull/135.  If it's merged before the vmm-sys-util dependency is updated to a version with that change, it will produce compiler warnings, so I've marked it as a draft until that PR is merged.
