### PR TITLE
vhost-user: Implement FromRawFd for Listener

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 80.9, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 81.0, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}


### PR DESCRIPTION
Implement FromRawFd for Listener, using the underlying UnixListener
FromRawFd implementation.

This is useful when the listener socket is inherited as a file
descriptor from a parent (such as libvirt or a jailer).

Signed-off-by: Sergio Lopez <slp@redhat.com>