### PR TITLE
Cargo: replace wildcard with 0.5 for serial_test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ vm-memory = "0.6"
 [dev-dependencies]
 tempfile = ">=3.2.0"
 vm-memory = { version = "0.6", features=["backend-mmap"] }
-serial_test = "*"
+serial_test = "0.5"


### PR DESCRIPTION
crates.io does not allow publishing crates which have wildcards in
their dependencies. We had one for "serial_test", so replace the
wildcard pointing it to the current major/minor ("0.5").

Signed-off-by: Sergio Lopez <slp@redhat.com>