### PR TITLE
Add method to restore Vdpa objects

### DIFF
--- a/LICENSE-BSD-3-Clause
+++ b/LICENSE-BSD-3-Clause
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Copyright (C) 2019 Alibaba Cloud. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -10,9 +10,9 @@
 // copyright notice, this list of conditions and the following disclaimer
 // in the documentation and/or other materials provided with the
 // distribution.
-//    * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//    * Neither the name of Alibaba Inc. nor the names of its contributors
+// may be used to endorse or promote products derived from this software
+// without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/src/vhost_kern/vdpa.rs
+++ b/src/vhost_kern/vdpa.rs
@@ -52,6 +52,15 @@ impl<AS: GuestAddressSpace> VhostKernVdpa<AS> {
             backend_features_acked: 0,
         })
     }
+
+    /// Create a `VhostKernVdpa` object with given content.
+    pub fn with(fd: File, mem: AS, backend_features_acked: u64) -> Self {
+        VhostKernVdpa {
+            fd,
+            mem,
+            backend_features_acked,
+        }
+    }
 }
 
 impl<AS: GuestAddressSpace> VhostVdpa for VhostKernVdpa<AS> {


### PR DESCRIPTION
Add methods to restore Vdpa objects, so we could avoid marking all fields of VhostKernVdpa as pub.