### PR TITLE
fix CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add the list of code owners here (using their GitHub username)
-* gatekeeper-PullAssigner @jiangliu @eryugey @sboeuf @slp @stefano-garzarella
+* @eryugey @jiangliu @sboeuf @slp @stefano-garzarella


### PR DESCRIPTION
The gatekeeper-PullAssigner was not correctly added in
the codeowners file (with its github handle). Removed it
from the file, so that the codewners are automatically
requested to review a new PR.
Since I was here, also reordered alphabetically the users.

Signed-off-by: Laura Loghin <lauralg@amazon.com>