### PR TITLE
vhost_kern/vdpa: fix get_iova_range()

### DIFF
--- a/src/vhost_kern/vdpa.rs
+++ b/src/vhost_kern/vdpa.rs
@@ -139,7 +139,7 @@ impl<AS: GuestAddressSpace> VhostVdpa for VhostKernVdpa<AS> {
         let mut low_iova_range = vhost_vdpa_iova_range { first: 0, last: 0 };
 
         let ret =
-            unsafe { ioctl_with_mut_ref(self, VHOST_VDPA_GET_VRING_NUM(), &mut low_iova_range) };
+            unsafe { ioctl_with_mut_ref(self, VHOST_VDPA_GET_IOVA_RANGE(), &mut low_iova_range) };
 
         let iova_range = VhostVdpaIovaRange {
             first: low_iova_range.first,
@@ -364,6 +364,11 @@ mod tests {
         vdpa.set_backend_features(backend_features).unwrap();
 
         vdpa.set_owner().unwrap();
+
+        let iova_range = vdpa.get_iova_range().unwrap();
+        // vDPA-block simulator returns [0, u64::MAX] range
+        assert_eq!(iova_range.first, 0);
+        assert_eq!(iova_range.last, u64::MAX);
 
         vdpa.dma_map(0xFFFF_0000, 0xFFFF, std::ptr::null::<u8>(), false)
             .unwrap_err();


### PR DESCRIPTION
### Summary of the PR

A wrong ioctl request was used in get_iova_range().
Unfortunately, there was no test, otherwise the ioctl would fail.

Let's fix this by using the right ioctl request.
We also add a test by checking the values we expect from
a vDPA-block simulator that returns [0, u64::MAX] range.

Fixes  #106

Reported-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
