### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 
 ### Deprecated
 
+## [v0.4.0]
+
+### Added
+- [[#109]](https://github.com/rust-vmm/vhost/pull/109) vhost_kern: vdpa: Override the implementation of valid()
+
+### Fixed
+- [[#102]](https://github.com/rust-vmm/vhost/pull/102) Fix warnings and update test coverage
+- [[#104]](https://github.com/rust-vmm/vhost/pull/104) fix CODEOWNERS file
+- [[#107]](https://github.com/rust-vmm/vhost/pull/107) vhost_kern/vdpa: fix get_iova_range()
+
 ## [v0.3.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.3.0"
+version = "0.4.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
### Summary of the PR

This release contains some fixes for the CI as well as the CODEOWNERS
file. It fixes the implementation of get_iova_range() for vDPA, and
finally it implements its own version of the VhostKernBackend::valid()
method for vDPA.

#### Added
- [[#109]](https://github.com/rust-vmm/vhost/pull/109) vhost_kern: vdpa: Override the implementation of valid()

#### Fixed
- [[#102]](https://github.com/rust-vmm/vhost/pull/102) Fix warnings and update test coverage
- [[#104]](https://github.com/rust-vmm/vhost/pull/104) fix CODEOWNERS file
- [[#107]](https://github.com/rust-vmm/vhost/pull/107) vhost_kern/vdpa: fix get_iova_range()

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
