### PR TITLE
vhost_user: expand error messages for clarity

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 79.9, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}
+{"coverage_score": 80.5, "exclude_path": "src/vhost_kern/", "crate_features": "vhost-user-master,vhost-user-slave"}

--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -380,7 +380,9 @@ impl VhostUserMaster for Master {
         let mut node = self.node();
         // set_vring_enable() is supported only when PROTOCOL_FEATURES has been enabled.
         if node.acked_virtio_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() == 0 {
-            return error_code(VhostUserError::InvalidOperation);
+            return error_code(VhostUserError::InactiveFeature(
+                VhostUserVirtioFeatures::PROTOCOL_FEATURES,
+            ));
         } else if queue_index as u64 >= node.max_queue_num {
             return error_code(VhostUserError::InvalidParam);
         }
@@ -730,7 +732,7 @@ impl MasterInternal {
         if self.virtio_features & feat.bits() != 0 {
             Ok(())
         } else {
-            Err(VhostUserError::InvalidOperation)
+            Err(VhostUserError::InactiveFeature(feat))
         }
     }
 
@@ -738,7 +740,7 @@ impl MasterInternal {
         if self.acked_protocol_features & feat.bits() != 0 {
             Ok(())
         } else {
-            Err(VhostUserError::InvalidOperation)
+            Err(VhostUserError::InactiveOperation(feat))
         }
     }
 

--- a/src/vhost_user/message.rs
+++ b/src/vhost_user/message.rs
@@ -3,7 +3,7 @@
 
 //! Define communication messages for the vhost-user protocol.
 //!
-//! For message definition, please refer to the [vhost-user spec](https://github.com/qemu/qemu/blob/f7526eece29cd2e36a63b6703508b24453095eb8/docs/interop/vhost-user.txt).
+//! For message definition, please refer to the [vhost-user spec](https://qemu.readthedocs.io/en/latest/interop/vhost-user.html).
 
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]

--- a/src/vhost_user/slave_req_handler.rs
+++ b/src/vhost_user/slave_req_handler.rs
@@ -273,7 +273,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         if self.acked_virtio_features & feat.bits() != 0 {
             Ok(())
         } else {
-            Err(Error::InvalidOperation)
+            Err(Error::InactiveFeature(feat))
         }
     }
 
@@ -281,7 +281,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         if self.acked_protocol_features & feat.bits() != 0 {
             Ok(())
         } else {
-            Err(Error::InvalidOperation)
+            Err(Error::InactiveOperation(feat))
         }
     }
 


### PR DESCRIPTION
### Summary of the PR

The InvalidOperation error type covers a wide range of error cases
which can be inscrutable when passed to the user. To help with this
we:

  - add a textual reason field to the error message
  - create InactiveFeature for use of un-neogitated features
  - create InactiveOperation for use of un-negotiated protocol extensions

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
