### PR TITLE
vhost_kern: vdpa: Add missing ioctls

### DIFF
--- a/src/vdpa.rs
+++ b/src/vdpa.rs
@@ -77,6 +77,37 @@ pub trait VhostVdpa: VhostBackend {
     /// Get the valid I/O virtual addresses range supported by the device.
     fn get_iova_range(&self) -> Result<VhostVdpaIovaRange>;
 
+    /// Get the config size
+    fn get_config_size(&self) -> Result<u32>;
+
+    /// Get the count of all virtqueues
+    fn get_vqs_count(&self) -> Result<u32>;
+
+    /// Get the number of virtqueue groups
+    fn get_group_num(&self) -> Result<u32>;
+
+    /// Get the number of address spaces
+    fn get_as_num(&self) -> Result<u32>;
+
+    /// Get the group for a virtqueue.
+    /// The virtqueue index is stored in the index field of
+    /// vhost_vring_state. The group for this specific virtqueue is
+    /// returned via num field of vhost_vring_state.
+    fn get_vring_group(&self, queue_index: u32) -> Result<u32>;
+
+    /// Set the ASID for a virtqueue group. The group index is stored in
+    /// the index field of vhost_vring_state, the ASID associated with this
+    /// group is stored at num field of vhost_vring_state.
+    fn set_group_asid(&self, group_index: u32, asid: u32) -> Result<()>;
+
+    /// Suspend a device so it does not process virtqueue requests anymore
+    ///
+    /// After the return of ioctl the device must preserve all the necessary state
+    /// (the virtqueue vring base plus the possible device specific states) that is
+    /// required for restoring in the future. The device must not change its
+    /// configuration after that point.
+    fn suspend(&self) -> Result<()>;
+
     /// Map DMA region.
     ///
     /// # Arguments

--- a/src/vhost_kern/vhost_binding.rs
+++ b/src/vhost_kern/vhost_binding.rs
@@ -40,6 +40,8 @@ pub const VHOST_NET_F_VIRTIO_NET_HDR: raw::c_uint = 27;
 pub const VHOST_SCSI_ABI_VERSION: raw::c_uint = 1;
 pub const VHOST_BACKEND_F_IOTLB_MSG_V2: raw::c_ulonglong = 0x1;
 pub const VHOST_BACKEND_F_IOTLB_BATCH: raw::c_ulonglong = 0x2;
+pub const VHOST_BACKEND_F_IOTLB_ASID: raw::c_ulonglong = 0x3;
+pub const VHOST_BACKEND_F_SUSPEND: raw::c_ulonglong = 0x4;
 
 ioctl_ior_nr!(VHOST_GET_FEATURES, VHOST, 0x00, raw::c_ulonglong);
 ioctl_iow_nr!(VHOST_SET_FEATURES, VHOST, 0x00, raw::c_ulonglong);
@@ -79,6 +81,13 @@ ioctl_ior_nr!(
     0x78,
     vhost_vdpa_iova_range
 );
+ioctl_ior_nr!(VHOST_VDPA_GET_CONFIG_SIZE, VHOST, 0x79, raw::c_uint);
+ioctl_ior_nr!(VHOST_VDPA_GET_VQS_COUNT, VHOST, 0x80, raw::c_uint);
+ioctl_ior_nr!(VHOST_VDPA_GET_GROUP_NUM, VHOST, 0x81, raw::c_uint);
+ioctl_ior_nr!(VHOST_VDPA_GET_AS_NUM, VHOST, 0x7a, raw::c_uint);
+ioctl_iowr_nr!(VHOST_VDPA_GET_VRING_GROUP, VHOST, 0x7b, vhost_vring_state);
+ioctl_iow_nr!(VHOST_VDPA_SET_GROUP_ASID, VHOST, 0x7c, vhost_vring_state);
+ioctl_io_nr!(VHOST_VDPA_SUSPEND, VHOST, 0x7d);
 
 #[repr(C)]
 #[derive(Default)]

--- a/src/vhost_user/connection.rs
+++ b/src/vhost_user/connection.rs
@@ -356,7 +356,7 @@ impl<R: Req> Endpoint<R> {
                     .take(n)
                     .map(|fd| {
                         // Safe because we have the ownership of `fd`.
-                        unsafe { File::from_raw_fd(*fd) }
+                        File::from_raw_fd(*fd)
                     })
                     .collect();
                 Some(files)


### PR DESCRIPTION
New ioctls have been recently introduced to interact with vDPA devices.

This patch is based on Linux kernel v6.0, adding the list of missing ioctls:

- VHOST_VDPA_GET_CONFIG_SIZE
- VHOST_VDPA_GET_VQS_COUNT
- VHOST_VDPA_GET_GROUP_NUM
- VHOST_VDPA_GET_AS_NUM
- VHOST_VDPA_GET_VRING_GROUP
- VHOST_VDPA_SET_GROUP_ASID
- VHOST_VDPA_SUSPEND

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>