### PR TITLE
vhost_user: fix unsoundness in VhostUserMsgHeader

### DIFF
--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- [[#135]](https://github.com/rust-vmm/vhost/pull/135) vhost_user: fix UB on invalid master request
 
 ### Deprecated
 

--- a/crates/vhost/src/vhost_user/connection.rs
+++ b/crates/vhost/src/vhost_user/connection.rs
@@ -637,7 +637,7 @@ mod tests {
     #[test]
     fn create_listener() {
         let path = temp_path();
-        let listener = Listener::new(&path, true).unwrap();
+        let listener = Listener::new(path, true).unwrap();
 
         assert!(listener.as_raw_fd() > 0);
     }
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     fn accept_connection() {
         let path = temp_path();
-        let listener = Listener::new(&path, true).unwrap();
+        let listener = Listener::new(path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
 
         // accept on a fd without incoming connection

--- a/crates/vhost/src/vhost_user/master.rs
+++ b/crates/vhost/src/vhost_user/master.rs
@@ -797,13 +797,13 @@ mod tests {
         master.reset_owner().unwrap();
 
         let (hdr, rfds) = slave.recv_header().unwrap();
-        assert_eq!(hdr.get_code(), MasterReq::SET_OWNER);
+        assert_eq!(hdr.get_code().unwrap(), MasterReq::SET_OWNER);
         assert_eq!(hdr.get_size(), 0);
         assert_eq!(hdr.get_version(), 0x1);
         assert!(rfds.is_none());
 
         let (hdr, rfds) = slave.recv_header().unwrap();
-        assert_eq!(hdr.get_code(), MasterReq::RESET_OWNER);
+        assert_eq!(hdr.get_code().unwrap(), MasterReq::RESET_OWNER);
         assert_eq!(hdr.get_size(), 0);
         assert_eq!(hdr.get_version(), 0x1);
         assert!(rfds.is_none());
@@ -831,7 +831,7 @@ mod tests {
 
         master.set_owner().unwrap();
         let (hdr, rfds) = peer.recv_header().unwrap();
-        assert_eq!(hdr.get_code(), MasterReq::SET_OWNER);
+        assert_eq!(hdr.get_code().unwrap(), MasterReq::SET_OWNER);
         assert_eq!(hdr.get_size(), 0);
         assert_eq!(hdr.get_version(), 0x1);
         assert!(rfds.is_none());
@@ -866,7 +866,7 @@ mod tests {
 
         master.set_owner().unwrap();
         let (hdr, rfds) = peer.recv_header().unwrap();
-        assert_eq!(hdr.get_code(), MasterReq::SET_OWNER);
+        assert_eq!(hdr.get_code().unwrap(), MasterReq::SET_OWNER);
         assert!(rfds.is_none());
 
         assert!(master.get_protocol_features().is_err());

--- a/crates/vhost/src/vhost_user/master.rs
+++ b/crates/vhost/src/vhost_user/master.rs
@@ -827,7 +827,7 @@ mod tests {
     #[test]
     fn test_features() {
         let path = temp_path();
-        let (master, mut peer) = create_pair(&path);
+        let (master, mut peer) = create_pair(path);
 
         master.set_owner().unwrap();
         let (hdr, rfds) = peer.recv_header().unwrap();
@@ -862,7 +862,7 @@ mod tests {
     #[test]
     fn test_protocol_features() {
         let path = temp_path();
-        let (mut master, mut peer) = create_pair(&path);
+        let (mut master, mut peer) = create_pair(path);
 
         master.set_owner().unwrap();
         let (hdr, rfds) = peer.recv_header().unwrap();
@@ -913,7 +913,7 @@ mod tests {
     #[test]
     fn test_master_set_config_negative() {
         let path = temp_path();
-        let (mut master, _peer) = create_pair(&path);
+        let (mut master, _peer) = create_pair(path);
         let buf = vec![0x0; MAX_MSG_SIZE + 1];
 
         master
@@ -958,7 +958,7 @@ mod tests {
 
     fn create_pair2() -> (Master, Endpoint<MasterReq>) {
         let path = temp_path();
-        let (master, peer) = create_pair(&path);
+        let (master, peer) = create_pair(path);
 
         {
             let mut node = master.node();

--- a/crates/vhost/src/vhost_user/master_req_handler.rs
+++ b/crates/vhost/src/vhost_user/master_req_handler.rs
@@ -216,32 +216,32 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
         };
 
         let res = match hdr.get_code() {
-            SlaveReq::CONFIG_CHANGE_MSG => {
+            Ok(SlaveReq::CONFIG_CHANGE_MSG) => {
                 self.check_msg_size(&hdr, size, 0)?;
                 self.backend
                     .handle_config_change()
                     .map_err(Error::ReqHandlerError)
             }
-            SlaveReq::FS_MAP => {
+            Ok(SlaveReq::FS_MAP) => {
                 let msg = self.extract_msg_body::<VhostUserFSSlaveMsg>(&hdr, size, &buf)?;
                 // check_attached_files() has validated files
                 self.backend
                     .fs_slave_map(&msg, &files.unwrap()[0])
                     .map_err(Error::ReqHandlerError)
             }
-            SlaveReq::FS_UNMAP => {
+            Ok(SlaveReq::FS_UNMAP) => {
                 let msg = self.extract_msg_body::<VhostUserFSSlaveMsg>(&hdr, size, &buf)?;
                 self.backend
                     .fs_slave_unmap(&msg)
                     .map_err(Error::ReqHandlerError)
             }
-            SlaveReq::FS_SYNC => {
+            Ok(SlaveReq::FS_SYNC) => {
                 let msg = self.extract_msg_body::<VhostUserFSSlaveMsg>(&hdr, size, &buf)?;
                 self.backend
                     .fs_slave_sync(&msg)
                     .map_err(Error::ReqHandlerError)
             }
-            SlaveReq::FS_IO => {
+            Ok(SlaveReq::FS_IO) => {
                 let msg = self.extract_msg_body::<VhostUserFSSlaveMsg>(&hdr, size, &buf)?;
                 // check_attached_files() has validated files
                 self.backend
@@ -285,7 +285,7 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
         files: &Option<Vec<File>>,
     ) -> Result<()> {
         match hdr.get_code() {
-            SlaveReq::FS_MAP | SlaveReq::FS_IO => {
+            Ok(SlaveReq::FS_MAP | SlaveReq::FS_IO) => {
                 // Expect a single file is passed.
                 match files {
                     Some(files) if files.len() == 1 => Ok(()),
@@ -320,7 +320,7 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
         }
         self.check_state()?;
         Ok(VhostUserMsgHeader::new(
-            req.get_code(),
+            req.get_code()?,
             VhostUserHeaderFlag::REPLY.bits(),
             mem::size_of::<T>() as u32,
         ))

--- a/crates/vhost/src/vhost_user/master_req_handler.rs
+++ b/crates/vhost/src/vhost_user/master_req_handler.rs
@@ -336,7 +336,7 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
             let def_err = libc::EINVAL;
             let val = match res {
                 Ok(n) => *n,
-                Err(e) => match &*e {
+                Err(e) => match e {
                     Error::ReqHandlerError(ioerr) => match ioerr.raw_os_error() {
                         Some(rawerr) => -rawerr as u64,
                         None => -def_err as u64,

--- a/crates/vhost/src/vhost_user/message.rs
+++ b/crates/vhost/src/vhost_user/message.rs
@@ -624,7 +624,7 @@ impl VhostUserVringAddr {
     }
 
     /// Create a new instance from `VringConfigData`.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::identity_conversion))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
     pub fn from_config_data(index: u32, config_data: &VringConfigData) -> Self {
         let log_addr = config_data.log_addr.unwrap_or(0);
         VhostUserVringAddr {

--- a/crates/vhost/src/vhost_user/mod.rs
+++ b/crates/vhost/src/vhost_user/mod.rs
@@ -267,7 +267,7 @@ mod tests {
     fn test_set_owner() {
         let slave_be = Arc::new(Mutex::new(DummySlaveReqHandler::new()));
         let path = temp_path();
-        let (master, mut slave) = create_slave(&path, slave_be.clone());
+        let (master, mut slave) = create_slave(path, slave_be.clone());
 
         assert!(!slave_be.lock().unwrap().owned);
         master.set_owner().unwrap();
@@ -284,7 +284,7 @@ mod tests {
         let sbar = mbar.clone();
         let path = temp_path();
         let slave_be = Arc::new(Mutex::new(DummySlaveReqHandler::new()));
-        let (mut master, mut slave) = create_slave(&path, slave_be.clone());
+        let (mut master, mut slave) = create_slave(path, slave_be.clone());
 
         thread::spawn(move || {
             slave.handle_request().unwrap();
@@ -328,7 +328,7 @@ mod tests {
         let sbar = mbar.clone();
         let path = temp_path();
         let slave_be = Arc::new(Mutex::new(DummySlaveReqHandler::new()));
-        let (mut master, mut slave) = create_slave(&path, slave_be.clone());
+        let (mut master, mut slave) = create_slave(path, slave_be.clone());
 
         thread::spawn(move || {
             // set_own()

--- a/crates/vhost/src/vhost_user/slave_req_handler.rs
+++ b/crates/vhost/src/vhost_user/slave_req_handler.rs
@@ -340,17 +340,17 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         };
 
         match hdr.get_code() {
-            MasterReq::SET_OWNER => {
+            Ok(MasterReq::SET_OWNER) => {
                 self.check_request_size(&hdr, size, 0)?;
                 let res = self.backend.set_owner();
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::RESET_OWNER => {
+            Ok(MasterReq::RESET_OWNER) => {
                 self.check_request_size(&hdr, size, 0)?;
                 let res = self.backend.reset_owner();
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_FEATURES => {
+            Ok(MasterReq::GET_FEATURES) => {
                 self.check_request_size(&hdr, size, 0)?;
                 let features = self.backend.get_features()?;
                 let msg = VhostUserU64::new(features);
@@ -358,23 +358,23 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 self.virtio_features = features;
                 self.update_reply_ack_flag();
             }
-            MasterReq::SET_FEATURES => {
+            Ok(MasterReq::SET_FEATURES) => {
                 let msg = self.extract_request_body::<VhostUserU64>(&hdr, size, &buf)?;
                 let res = self.backend.set_features(msg.value);
                 self.acked_virtio_features = msg.value;
                 self.update_reply_ack_flag();
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_MEM_TABLE => {
+            Ok(MasterReq::SET_MEM_TABLE) => {
                 let res = self.set_mem_table(&hdr, size, &buf, files);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_VRING_NUM => {
+            Ok(MasterReq::SET_VRING_NUM) => {
                 let msg = self.extract_request_body::<VhostUserVringState>(&hdr, size, &buf)?;
                 let res = self.backend.set_vring_num(msg.index, msg.num);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_VRING_ADDR => {
+            Ok(MasterReq::SET_VRING_ADDR) => {
                 let msg = self.extract_request_body::<VhostUserVringAddr>(&hdr, size, &buf)?;
                 let flags = match VhostUserVringAddrFlags::from_bits(msg.flags) {
                     Some(val) => val,
@@ -390,35 +390,35 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 );
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_VRING_BASE => {
+            Ok(MasterReq::SET_VRING_BASE) => {
                 let msg = self.extract_request_body::<VhostUserVringState>(&hdr, size, &buf)?;
                 let res = self.backend.set_vring_base(msg.index, msg.num);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_VRING_BASE => {
+            Ok(MasterReq::GET_VRING_BASE) => {
                 let msg = self.extract_request_body::<VhostUserVringState>(&hdr, size, &buf)?;
                 let reply = self.backend.get_vring_base(msg.index)?;
                 self.send_reply_message(&hdr, &reply)?;
             }
-            MasterReq::SET_VRING_CALL => {
+            Ok(MasterReq::SET_VRING_CALL) => {
                 self.check_request_size(&hdr, size, mem::size_of::<VhostUserU64>())?;
                 let (index, file) = self.handle_vring_fd_request(&buf, files)?;
                 let res = self.backend.set_vring_call(index, file);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_VRING_KICK => {
+            Ok(MasterReq::SET_VRING_KICK) => {
                 self.check_request_size(&hdr, size, mem::size_of::<VhostUserU64>())?;
                 let (index, file) = self.handle_vring_fd_request(&buf, files)?;
                 let res = self.backend.set_vring_kick(index, file);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_VRING_ERR => {
+            Ok(MasterReq::SET_VRING_ERR) => {
                 self.check_request_size(&hdr, size, mem::size_of::<VhostUserU64>())?;
                 let (index, file) = self.handle_vring_fd_request(&buf, files)?;
                 let res = self.backend.set_vring_err(index, file);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_PROTOCOL_FEATURES => {
+            Ok(MasterReq::GET_PROTOCOL_FEATURES) => {
                 self.check_request_size(&hdr, size, 0)?;
                 let features = self.backend.get_protocol_features()?;
                 let msg = VhostUserU64::new(features.bits());
@@ -426,21 +426,21 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 self.protocol_features = features;
                 self.update_reply_ack_flag();
             }
-            MasterReq::SET_PROTOCOL_FEATURES => {
+            Ok(MasterReq::SET_PROTOCOL_FEATURES) => {
                 let msg = self.extract_request_body::<VhostUserU64>(&hdr, size, &buf)?;
                 let res = self.backend.set_protocol_features(msg.value);
                 self.acked_protocol_features = msg.value;
                 self.update_reply_ack_flag();
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_QUEUE_NUM => {
+            Ok(MasterReq::GET_QUEUE_NUM) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::MQ)?;
                 self.check_request_size(&hdr, size, 0)?;
                 let num = self.backend.get_queue_num()?;
                 let msg = VhostUserU64::new(num);
                 self.send_reply_message(&hdr, &msg)?;
             }
-            MasterReq::SET_VRING_ENABLE => {
+            Ok(MasterReq::SET_VRING_ENABLE) => {
                 let msg = self.extract_request_body::<VhostUserVringState>(&hdr, size, &buf)?;
                 self.check_feature(VhostUserVirtioFeatures::PROTOCOL_FEATURES)?;
                 let enable = match msg.num {
@@ -452,24 +452,24 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 let res = self.backend.set_vring_enable(msg.index, enable);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_CONFIG => {
+            Ok(MasterReq::GET_CONFIG) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIG)?;
                 self.check_request_size(&hdr, size, hdr.get_size() as usize)?;
                 self.get_config(&hdr, &buf)?;
             }
-            MasterReq::SET_CONFIG => {
+            Ok(MasterReq::SET_CONFIG) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIG)?;
                 self.check_request_size(&hdr, size, hdr.get_size() as usize)?;
                 let res = self.set_config(size, &buf);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::SET_SLAVE_REQ_FD => {
+            Ok(MasterReq::SET_SLAVE_REQ_FD) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::SLAVE_REQ)?;
                 self.check_request_size(&hdr, size, hdr.get_size() as usize)?;
                 let res = self.set_slave_req_fd(files);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_INFLIGHT_FD => {
+            Ok(MasterReq::GET_INFLIGHT_FD) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::INFLIGHT_SHMFD)?;
 
                 let msg = self.extract_request_body::<VhostUserInflight>(&hdr, size, &buf)?;
@@ -478,21 +478,21 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 self.main_sock
                     .send_message(&reply_hdr, &inflight, Some(&[file.as_raw_fd()]))?;
             }
-            MasterReq::SET_INFLIGHT_FD => {
+            Ok(MasterReq::SET_INFLIGHT_FD) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::INFLIGHT_SHMFD)?;
                 let file = take_single_file(files).ok_or(Error::IncorrectFds)?;
                 let msg = self.extract_request_body::<VhostUserInflight>(&hdr, size, &buf)?;
                 let res = self.backend.set_inflight_fd(&msg, file);
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::GET_MAX_MEM_SLOTS => {
+            Ok(MasterReq::GET_MAX_MEM_SLOTS) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS)?;
                 self.check_request_size(&hdr, size, 0)?;
                 let num = self.backend.get_max_mem_slots()?;
                 let msg = VhostUserU64::new(num);
                 self.send_reply_message(&hdr, &msg)?;
             }
-            MasterReq::ADD_MEM_REG => {
+            Ok(MasterReq::ADD_MEM_REG) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS)?;
                 let mut files = files.ok_or(Error::InvalidParam)?;
                 if files.len() != 1 {
@@ -503,7 +503,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 let res = self.backend.add_mem_region(&msg, files.swap_remove(0));
                 self.send_ack_message(&hdr, res)?;
             }
-            MasterReq::REM_MEM_REG => {
+            Ok(MasterReq::REM_MEM_REG) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS)?;
 
                 let msg =
@@ -683,15 +683,17 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         files: &Option<Vec<File>>,
     ) -> Result<()> {
         match hdr.get_code() {
-            MasterReq::SET_MEM_TABLE
-            | MasterReq::SET_VRING_CALL
-            | MasterReq::SET_VRING_KICK
-            | MasterReq::SET_VRING_ERR
-            | MasterReq::SET_LOG_BASE
-            | MasterReq::SET_LOG_FD
-            | MasterReq::SET_SLAVE_REQ_FD
-            | MasterReq::SET_INFLIGHT_FD
-            | MasterReq::ADD_MEM_REG => Ok(()),
+            Ok(
+                MasterReq::SET_MEM_TABLE
+                | MasterReq::SET_VRING_CALL
+                | MasterReq::SET_VRING_KICK
+                | MasterReq::SET_VRING_ERR
+                | MasterReq::SET_LOG_BASE
+                | MasterReq::SET_LOG_FD
+                | MasterReq::SET_SLAVE_REQ_FD
+                | MasterReq::SET_INFLIGHT_FD
+                | MasterReq::ADD_MEM_REG,
+            ) => Ok(()),
             _ if files.is_some() => Err(Error::InvalidMessage),
             _ => Ok(()),
         }
@@ -737,7 +739,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         }
         self.check_state()?;
         Ok(VhostUserMsgHeader::new(
-            req.get_code(),
+            req.get_code()?,
             VhostUserHeaderFlag::REPLY.bits(),
             (mem::size_of::<T>() + payload_size) as u32,
         ))

--- a/crates/vhost/src/vhost_user/slave_req_handler.rs
+++ b/crates/vhost/src/vhost_user/slave_req_handler.rs
@@ -611,11 +611,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         if size - mem::size_of::<VhostUserConfig>() != msg.size as usize {
             return Err(Error::InvalidMessage);
         }
-        let flags: VhostUserConfigFlags;
-        match VhostUserConfigFlags::from_bits(msg.flags) {
-            Some(val) => flags = val,
-            None => return Err(Error::InvalidMessage),
-        }
+        let flags = VhostUserConfigFlags::from_bits(msg.flags).ok_or(Error::InvalidMessage)?;
 
         self.backend
             .set_config(msg.offset, &buf[mem::size_of::<VhostUserConfig>()..], flags)


### PR DESCRIPTION
### Summary of the PR

Since `VhostUserMsgHeader` implements `ByteValued`, it is supposed to be safe to construct from any correctly-sized arbitrary byte array. But that means we can do this:

```rust
let bytes = b"\xFF\xFF\xFF\xFF\x00\x00\x00\x00\x00\x00\x00\x00";
let header = VhostUserMsgHeader::<MasterReq>::from_slice(bytes).unwrap();
header.get_code()
```

constructing an invalid `MasterReq`, using only functions that are marked as safe.  Constructing an invalid enum value is undefined behavior in Rust, so this API is unsound.  This wasn't considered by the safety comment in `VhostUserMsgHeader::get_code`, which only considered the safety of requests that were valid enum variants.

If the vhost-user frontend process sends a message that the backend doesn't recognise, that's exactly what will happen, so the UB can be triggered from an external process (but a trusted one).

To fix this, we need to check whether the value is valid _before_ converting it.  `Req::is_valid` is changed to be a non-instance method, so it can be called before constructing the `Req`.
`VhostUserMsgHeader::get_code` is changed to return a `Result`, to accomodate the case where the request number is not a valid value for `R`.

Since this unsoundness is exposed to other processes, I will apply for an informational (not vulnerability) RUSTSEC advisory for this issue.

Signed-off-by: Alyssa Ross <alyssa.ross@unikie.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
