### PR TITLE
vhost_user: fix unsound send_message functions

### DIFF
--- a/crates/vhost/src/vhost_user/connection.rs
+++ b/crates/vhost/src/vhost_user/connection.rs
@@ -224,7 +224,7 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketBroken: the underline socket is broken.
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
-    pub fn send_message<T: Sized>(
+    pub fn send_message<T: ByteValued>(
         &mut self,
         hdr: &VhostUserMsgHeader<R>,
         body: &T,
@@ -261,7 +261,7 @@ impl<R: Req> Endpoint<R> {
     /// * - OversizedMsg: message size is too big.
     /// * - PartialMessage: received a partial message.
     /// * - IncorrectFds: wrong number of attached fds.
-    pub fn send_message_with_payload<T: Sized>(
+    pub fn send_message_with_payload<T: ByteValued>(
         &mut self,
         hdr: &VhostUserMsgHeader<R>,
         body: &T,

--- a/crates/vhost/src/vhost_user/master.rs
+++ b/crates/vhost/src/vhost_user/master.rs
@@ -591,7 +591,7 @@ impl MasterInternal {
         Ok(hdr)
     }
 
-    fn send_request_with_body<T: Sized>(
+    fn send_request_with_body<T: ByteValued>(
         &mut self,
         code: MasterReq,
         msg: &T,
@@ -607,7 +607,7 @@ impl MasterInternal {
         Ok(hdr)
     }
 
-    fn send_request_with_payload<T: Sized>(
+    fn send_request_with_payload<T: ByteValued>(
         &mut self,
         code: MasterReq,
         msg: &T,

--- a/crates/vhost/src/vhost_user/message.rs
+++ b/crates/vhost/src/vhost_user/message.rs
@@ -435,7 +435,7 @@ impl VhostUserMsgValidator for VhostUserU64 {}
 
 /// Memory region descriptor for the SET_MEM_TABLE request.
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Copy, Clone, Default)]
 pub struct VhostUserMemory {
     /// Number of memory regions in the payload.
     pub num_regions: u32,
@@ -452,6 +452,8 @@ impl VhostUserMemory {
         }
     }
 }
+
+unsafe impl ByteValued for VhostUserMemory {}
 
 impl VhostUserMsgValidator for VhostUserMemory {
     #[allow(clippy::if_same_then_else)]
@@ -537,6 +539,8 @@ impl VhostUserSingleMemoryRegion {
     }
 }
 
+unsafe impl ByteValued for VhostUserSingleMemoryRegion {}
+
 impl VhostUserMsgValidator for VhostUserSingleMemoryRegion {
     fn is_valid(&self) -> bool {
         if self.memory_size == 0
@@ -583,7 +587,7 @@ bitflags! {
 
 /// Vring address descriptor.
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Copy, Clone, Default)]
 pub struct VhostUserVringAddr {
     /// Vring index.
     pub index: u32,
@@ -633,6 +637,8 @@ impl VhostUserVringAddr {
         }
     }
 }
+
+unsafe impl ByteValued for VhostUserVringAddr {}
 
 impl VhostUserMsgValidator for VhostUserVringAddr {
     #[allow(clippy::if_same_then_else)]
@@ -745,7 +751,7 @@ impl VhostUserMsgValidator for VhostUserInflight {
 
 /// Single memory region descriptor as payload for SET_LOG_BASE request.
 #[repr(C)]
-#[derive(Default, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct VhostUserLog {
     /// Size of the area to log dirty pages.
     pub mmap_size: u64,
@@ -762,6 +768,8 @@ impl VhostUserLog {
         }
     }
 }
+
+unsafe impl ByteValued for VhostUserLog {}
 
 impl VhostUserMsgValidator for VhostUserLog {
     fn is_valid(&self) -> bool {
@@ -817,7 +825,7 @@ pub const VHOST_USER_FS_SLAVE_ENTRIES: usize = 8;
 
 /// Slave request message to update the MMIO window.
 #[repr(packed)]
-#[derive(Default)]
+#[derive(Copy, Clone, Default)]
 pub struct VhostUserFSSlaveMsg {
     /// File offset.
     pub fd_offset: [u64; VHOST_USER_FS_SLAVE_ENTRIES],
@@ -828,6 +836,8 @@ pub struct VhostUserFSSlaveMsg {
     /// Flags for the mmap operation
     pub flags: [VhostUserFSSlaveMsgFlags; VHOST_USER_FS_SLAVE_ENTRIES],
 }
+
+unsafe impl ByteValued for VhostUserFSSlaveMsg {}
 
 impl VhostUserMsgValidator for VhostUserFSSlaveMsg {
     fn is_valid(&self) -> bool {

--- a/crates/vhost/src/vhost_user/slave_req_handler.rs
+++ b/crates/vhost/src/vhost_user/slave_req_handler.rs
@@ -8,6 +8,8 @@ use std::os::unix::net::UnixStream;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
+use vm_memory::ByteValued;
+
 use super::connection::Endpoint;
 use super::message::*;
 use super::slave_fs_cache::SlaveFsCacheReq;
@@ -762,7 +764,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         res
     }
 
-    fn send_reply_message<T>(
+    fn send_reply_message<T: ByteValued>(
         &mut self,
         req: &VhostUserMsgHeader<MasterReq>,
         msg: &T,
@@ -772,7 +774,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
         Ok(())
     }
 
-    fn send_reply_with_payload<T: Sized>(
+    fn send_reply_with_payload<T: ByteValued>(
         &mut self,
         req: &VhostUserMsgHeader<MasterReq>,
         msg: &T,


### PR DESCRIPTION
### Summary of the PR

These functions were unsound because it was previously possible to trigger UB with them, but they were not marked as unsafe.

Struct padding in Rust is uninitialized.  So if a struct with padding had been passed to either of these functions as the body, it would have resulted in an uninitialized read, which is undefined behavior in Rust.

By restricting body values to be `ByteValued`, we avoid this, because types implementing `ByteValued` are guaranteed to be convertible to and from byte slices.

We then need to declare some types to be `ByteValued`, so that they can continue to be sent over the socket.

This is an internal-only API, and was never actually called incorrectly.

Signed-off-by: Alyssa Ross <alyssa.ross@unikie.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.

Wasn't sure if a CHANGELOG entry was required, since this is an internal-only change.  Let me know if so and I'll add one. :)