### PR TITLE
vhost_user: add Error::Disconnected

### DIFF
--- a/crates/vhost/src/vhost_user/mod.rs
+++ b/crates/vhost/src/vhost_user/mod.rs
@@ -68,6 +68,8 @@ pub enum Error {
     InvalidMessage,
     /// Only part of a message have been sent or received successfully
     PartialMessage,
+    /// The peer disconnected from the socket.
+    Disconnected,
     /// Message is too large
     OversizedMsg,
     /// Fd array in question is too big or too small
@@ -107,6 +109,7 @@ impl std::fmt::Display for Error {
             }
             Error::InvalidMessage => write!(f, "invalid message"),
             Error::PartialMessage => write!(f, "partial message"),
+            Error::Disconnected => write!(f, "peer disconnected"),
             Error::OversizedMsg => write!(f, "oversized message"),
             Error::IncorrectFds => write!(f, "wrong number of attached fds"),
             Error::SocketError(e) => write!(f, "socket error: {}", e),
@@ -147,6 +150,8 @@ impl Error {
             Error::MasterInternalError => true,
             // Should just retry the IO operation instead of rebuilding the underline connection.
             Error::SocketRetry(_) => false,
+            // Looks like the peer deliberately disconnected the socket.
+            Error::Disconnected => false,
             Error::InvalidParam | Error::InvalidOperation(_) => false,
             Error::InactiveFeature(_) | Error::InactiveOperation(_) => false,
             Error::InvalidMessage | Error::IncorrectFds | Error::OversizedMsg => false,


### PR DESCRIPTION
### Summary of the PR

It's important to be able to tell the difference between a client cleanly disconnecting (e.g. if a VM is shut down), and a partial message transmission.  To do this, introduce a new `Disconnected` error variant, to be used only when `recvmsg()` returns 0 when trying to receive a header, indicating the client disconnected after the last message.

Signed-off-by: Alyssa Ross <alyssa.ross@unikie.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.