### PR TITLE
vhost_user: Slave requests aren't only FS specific

### DIFF
--- a/crates/vhost-user-backend/src/backend.rs
+++ b/crates/vhost-user-backend/src/backend.rs
@@ -23,7 +23,7 @@ use std::ops::Deref;
 use std::sync::{Arc, Mutex, RwLock};
 
 use vhost::vhost_user::message::VhostUserProtocolFeatures;
-use vhost::vhost_user::SlaveFsCacheReq;
+use vhost::vhost_user::Slave;
 use vm_memory::bitmap::Bitmap;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
@@ -80,9 +80,7 @@ where
     ///
     /// A default implementation is provided as we cannot expect all backends to implement this
     /// function.
-    ///
-    /// TODO: this interface is designed only for vhost-user-fs, it should be refined.
-    fn set_slave_req_fd(&self, _vu_req: SlaveFsCacheReq) {}
+    fn set_slave_req_fd(&self, _slave: Slave) {}
 
     /// Get the map to map queue index to worker thread index.
     ///
@@ -163,9 +161,7 @@ where
     ///
     /// A default implementation is provided as we cannot expect all backends to implement this
     /// function.
-    ///
-    /// TODO: this interface is designed only for vhost-user-fs, it should be refined.
-    fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
+    fn set_slave_req_fd(&mut self, _slave: Slave) {}
 
     /// Get the map to map queue index to worker thread index.
     ///
@@ -240,8 +236,8 @@ where
         self.deref().update_memory(mem)
     }
 
-    fn set_slave_req_fd(&self, vu_req: SlaveFsCacheReq) {
-        self.deref().set_slave_req_fd(vu_req)
+    fn set_slave_req_fd(&self, slave: Slave) {
+        self.deref().set_slave_req_fd(slave)
     }
 
     fn queues_per_thread(&self) -> Vec<u64> {
@@ -305,8 +301,8 @@ where
         self.lock().unwrap().update_memory(mem)
     }
 
-    fn set_slave_req_fd(&self, vu_req: SlaveFsCacheReq) {
-        self.lock().unwrap().set_slave_req_fd(vu_req)
+    fn set_slave_req_fd(&self, slave: Slave) {
+        self.lock().unwrap().set_slave_req_fd(slave)
     }
 
     fn queues_per_thread(&self) -> Vec<u64> {
@@ -371,8 +367,8 @@ where
         self.write().unwrap().update_memory(mem)
     }
 
-    fn set_slave_req_fd(&self, vu_req: SlaveFsCacheReq) {
-        self.write().unwrap().set_slave_req_fd(vu_req)
+    fn set_slave_req_fd(&self, slave: Slave) {
+        self.write().unwrap().set_slave_req_fd(slave)
     }
 
     fn queues_per_thread(&self) -> Vec<u64> {
@@ -463,7 +459,7 @@ pub mod tests {
             Ok(())
         }
 
-        fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
+        fn set_slave_req_fd(&mut self, _slave: Slave) {}
 
         fn queues_per_thread(&self) -> Vec<u64> {
             vec![1, 1]

--- a/crates/vhost-user-backend/src/handler.rs
+++ b/crates/vhost-user-backend/src/handler.rs
@@ -16,8 +16,7 @@ use vhost::vhost_user::message::{
     VhostUserVringState,
 };
 use vhost::vhost_user::{
-    Error as VhostUserError, Result as VhostUserResult, SlaveFsCacheReq,
-    VhostUserSlaveReqHandlerMut,
+    Error as VhostUserError, Result as VhostUserResult, Slave, VhostUserSlaveReqHandlerMut,
 };
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Error as VirtQueError, QueueT};
@@ -499,12 +498,12 @@ where
             .map_err(VhostUserError::ReqHandlerError)
     }
 
-    fn set_slave_req_fd(&mut self, vu_req: SlaveFsCacheReq) {
+    fn set_slave_req_fd(&mut self, slave: Slave) {
         if self.acked_protocol_features & VhostUserProtocolFeatures::REPLY_ACK.bits() != 0 {
-            vu_req.set_reply_ack_flag(true);
+            slave.set_reply_ack_flag(true);
         }
 
-        self.backend.set_slave_req_fd(vu_req);
+        self.backend.set_slave_req_fd(slave);
     }
 
     fn get_inflight_fd(

--- a/crates/vhost-user-backend/tests/vhost-user-server.rs
+++ b/crates/vhost-user-backend/tests/vhost-user-server.rs
@@ -10,7 +10,7 @@ use std::thread;
 use vhost::vhost_user::message::{
     VhostUserConfigFlags, VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures,
 };
-use vhost::vhost_user::{Listener, Master, SlaveFsCacheReq, VhostUserMaster};
+use vhost::vhost_user::{Listener, Master, Slave, VhostUserMaster};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
 use vm_memory::{
@@ -81,7 +81,7 @@ impl VhostUserBackendMut<VringRwLock, ()> for MockVhostBackend {
         Ok(())
     }
 
-    fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
+    fn set_slave_req_fd(&mut self, _slave: Slave) {}
 
     fn queues_per_thread(&self) -> Vec<u64> {
         vec![1, 1]

--- a/crates/vhost/docs/vhost_architecture.drawio
+++ b/crates/vhost/docs/vhost_architecture.drawio
@@ -27,7 +27,7 @@
                         </Array>
                     </mxGeometry>
                 </mxCell>
-                <mxCell id="5" value="&lt;pre style=&quot;font-family: &amp;quot;jetbrains mono&amp;quot;, monospace; font-size: 16.5pt;&quot;&gt;&lt;pre style=&quot;font-family: &amp;quot;jetbrains mono&amp;quot; , monospace ; font-size: 16.5pt&quot;&gt;SlaveFsCacheReq&lt;/pre&gt;&lt;/pre&gt;" style="rounded=0;whiteSpace=wrap;html=1;fontStyle=1;labelBackgroundColor=none;fontColor=#FF00FF;strokeColor=#FF00FF;" parent="1" vertex="1">
+                <mxCell id="5" value="&lt;pre style=&quot;font-family: &amp;quot;jetbrains mono&amp;quot;, monospace; font-size: 16.5pt;&quot;&gt;&lt;pre style=&quot;font-family: &amp;quot;jetbrains mono&amp;quot; , monospace ; font-size: 16.5pt&quot;&gt;Slave&lt;/pre&gt;&lt;/pre&gt;" style="rounded=0;whiteSpace=wrap;html=1;fontStyle=1;labelBackgroundColor=none;fontColor=#FF00FF;strokeColor=#FF00FF;" parent="1" vertex="1">
                     <mxGeometry x="1715" y="767" width="220" height="50" as="geometry"/>
                 </mxCell>
                 <mxCell id="7" value="&lt;pre style=&quot;font-size: 16.5pt; font-weight: 700; font-family: &amp;quot;jetbrains mono&amp;quot;, monospace;&quot;&gt;VhostUserMasterReqHandlerMut&lt;/pre&gt;" style="rounded=1;whiteSpace=wrap;html=1;labelBackgroundColor=none;fontColor=#FF00FF;strokeColor=#FF00FF;" vertex="1" parent="1">

--- a/crates/vhost/src/vhost_user/mod.rs
+++ b/crates/vhost/src/vhost_user/mod.rs
@@ -49,9 +49,9 @@ pub use self::slave_req_handler::{
     SlaveReqHandler, VhostUserSlaveReqHandler, VhostUserSlaveReqHandlerMut,
 };
 #[cfg(feature = "vhost-user-slave")]
-mod slave_fs_cache;
+mod slave_req;
 #[cfg(feature = "vhost-user-slave")]
-pub use self::slave_fs_cache::SlaveFsCacheReq;
+pub use self::slave_req::Slave;
 
 /// Errors for vhost-user operations
 #[derive(Debug)]


### PR DESCRIPTION
There are a lot of slave requests supported by vhost-user protocol, it isn't just about FS_MAP and FS_UNMAP. Rename the files and declarations to slave request specific names.