### PR TITLE
Add support for Xen memory mapping

### DIFF
--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -11,14 +11,14 @@ license = "Apache-2.0"
 [dependencies]
 libc = "0.2.39"
 log = "0.4.17"
-vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-slave"] }
-virtio-bindings = "0.1.0"
-virtio-queue = "0.7.0"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vhost = { path = "../vhost", features = ["vhost-user-slave"] }
+virtio-bindings = { git = "https://github.com/vireshk/vm-virtio", branch = "main" }
+virtio-queue = { git = "https://github.com/vireshk/vm-virtio", branch = "main" }
+vm-memory = { git = "https://github.com/vireshk/vm-memory", branch = "main", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 nix = "0.26"
-vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-master", "vhost-user-slave"] }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vhost = { path = "../vhost", features = ["vhost-user-master", "vhost-user-slave"] }
+vm-memory = { git = "https://github.com/vireshk/vm-memory", branch = "main", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/crates/vhost-user-backend/tests/vhost-user-server.rs
+++ b/crates/vhost-user-backend/tests/vhost-user-server.rs
@@ -53,7 +53,11 @@ impl VhostUserBackendMut<VringRwLock, ()> for MockVhostBackend {
     }
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::all()
+        let mut features = VhostUserProtocolFeatures::all();
+
+        // Disable Xen mmap feature.
+        features.remove(VhostUserProtocolFeatures::XEN_MMAP);
+        features
     }
 
     fn set_event_idx(&mut self, enabled: bool) {

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -28,9 +28,9 @@ bitflags = "1.0"
 libc = "0.2.39"
 
 vmm-sys-util = "0.11.0"
-vm-memory = "0.10.0"
+vm-memory = { git = "https://github.com/vireshk/vm-memory", branch = "main", features = ["backend-bitmap"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"
-vm-memory = { version = "0.10.0", features=["backend-mmap"] }
+vm-memory = { git = "https://github.com/vireshk/vm-memory", branch = "main", features = ["backend-mmap"] }
 serial_test = "0.5"

--- a/crates/vhost/src/vhost_kern/net.rs
+++ b/crates/vhost/src/vhost_kern/net.rs
@@ -127,7 +127,8 @@ mod tests {
 
         net.set_owner().unwrap();
 
-        net.set_mem_table(&[]).unwrap_err();
+        let region: Vec<VhostUserMemoryRegionInfo> = Vec::new();
+        net.set_mem_table(&region).unwrap_err();
 
         let region = VhostUserMemoryRegionInfo {
             guest_phys_addr: 0x0,

--- a/crates/vhost/src/vhost_kern/vdpa.rs
+++ b/crates/vhost/src/vhost_kern/vdpa.rs
@@ -367,7 +367,8 @@ mod tests {
 
         vdpa.set_owner().unwrap();
 
-        vdpa.set_mem_table(&[]).unwrap_err();
+        let region: Vec<VhostUserMemoryRegionInfo> = Vec::new();
+        vdpa.set_mem_table(&region).unwrap_err();
 
         let region = VhostUserMemoryRegionInfo {
             guest_phys_addr: 0x0,

--- a/crates/vhost/src/vhost_kern/vsock.rs
+++ b/crates/vhost/src/vhost_kern/vsock.rs
@@ -130,7 +130,8 @@ mod tests {
 
         vsock.set_owner().unwrap();
 
-        vsock.set_mem_table(&[]).unwrap_err();
+        let region: Vec<VhostUserMemoryRegionInfo> = Vec::new();
+        vsock.set_mem_table(&region).unwrap_err();
 
         /*
         let region = VhostUserMemoryRegionInfo {

--- a/crates/vhost/src/vhost_user/dummy_slave.rs
+++ b/crates/vhost/src/vhost_user/dummy_slave.rs
@@ -104,7 +104,7 @@ impl VhostUserSlaveReqHandlerMut for DummySlaveReqHandler {
         Ok(())
     }
 
-    fn set_mem_table(&mut self, _ctx: &[VhostUserMemoryRegion], _files: Vec<File>) -> Result<()> {
+    fn set_mem_table<R>(&mut self, _ctx: &[R], _files: Vec<File>) -> Result<()> {
         Ok(())
     }
 
@@ -284,11 +284,11 @@ impl VhostUserSlaveReqHandlerMut for DummySlaveReqHandler {
         Ok(MAX_MEM_SLOTS as u64)
     }
 
-    fn add_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion, _fd: File) -> Result<()> {
+    fn add_mem_region<R>(&mut self, _region: &R, _fd: File) -> Result<()> {
         Ok(())
     }
 
-    fn remove_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion) -> Result<()> {
+    fn remove_mem_region<R>(&mut self, _region: &R) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/vhost/src/vhost_user/mod.rs
+++ b/crates/vhost/src/vhost_user/mod.rs
@@ -348,6 +348,7 @@ mod tests {
             assert_eq!(
                 slave_be.lock().unwrap().acked_protocol_features,
                 VhostUserProtocolFeatures::all().bits()
+                    & !VhostUserProtocolFeatures::XEN_MMAP.bits()
             );
 
             // get_inflight_fd()
@@ -403,8 +404,11 @@ mod tests {
         master.set_features(VIRTIO_FEATURES & !0x1).unwrap();
 
         // set vhost protocol features
-        let features = master.get_protocol_features().unwrap();
+        let mut features = master.get_protocol_features().unwrap();
         assert_eq!(features.bits(), VhostUserProtocolFeatures::all().bits());
+
+        // Disable Xen mmap feature.
+        features.remove(VhostUserProtocolFeatures::XEN_MMAP);
         master.set_protocol_features(features).unwrap();
 
         // Retrieve inflight I/O tracking information


### PR DESCRIPTION
This pull request adds support to allow Xen specific memory mappings to be performed for specific memory regions.

The changes to the vhost-user protocol were shared here and are already Acked, though they aren't applied yet.

https://lore.kernel.org/all/cover.1678351495.git.viresh.kumar@linaro.org/

This depends on vm-memory pull request:

https://github.com/rust-vmm/vm-memory/pull/220