### PR TITLE
 Fix return value of `GET_VRING_BASE` message

### DIFF
--- a/crates/vhost-user-backend/src/handler.rs
+++ b/crates/vhost-user-backend/src/handler.rs
@@ -386,6 +386,8 @@ where
             }
         }
 
+        let next_avail = self.vrings[index as usize].queue_next_avail();
+
         self.vrings[index as usize].set_kick(None);
         self.vrings[index as usize].set_call(None);
 
@@ -396,8 +398,6 @@ where
             .get_mut()
             .get_queue_mut()
             .reset();
-
-        let next_avail = self.vrings[index as usize].queue_next_avail();
 
         Ok(VhostUserVringState::new(index, u32::from(next_avail)))
     }


### PR DESCRIPTION
### Summary of the PR

 When the frontend sends the `GET_VRING_BASE` message, we should return the vring's last available index and stop the vring.  Commit https://github.com/rust-vmm/vhost/commit/17131359ebae207476d009a65b702f028b581622 reset the vring upon receiving `GET_VRING_BASE`, But to return the correct index we should not reset the queue before getting its value, otherwise we will always return 0.

Note:
Neither qemu[0] nor dpdk[1] reset the vring when receiving `GET_VRING_BASE`

[0] https://github.com/qemu/qemu/blob/792f77f376adef944f9a03e601f6ad90c2f891b2/subprojects/libvhost-user/libvhost-user.c#L1175

[1] https://github.com/DPDK/dpdk/blob/d03446724972d2a1bb645ce7f3e64f5ef0203d61/lib/vhost/vhost_user.c#L2133
