### PR TITLE
Update deps and set up the stage for vhost v0.7.0 and vub v0.9.0

### DIFF
--- a/crates/vhost-user-backend/CHANGELOG.md
+++ b/crates/vhost-user-backend/CHANGELOG.md
@@ -9,10 +9,24 @@
 
 ### Deprecated
 
+## v0.9.0
+
+### Added
+- [[#138]](https://github.com/rust-vmm/vhost/pull/138): vhost-user-backend: add repository metadata
+
+### Changed
+- Updated dependency virtio-bindings 0.1.0 -> 0.2.0
+- Updated dependency virtio-queue 0.7.0 -> 0.8.0
+- Updated dependency vm-memory 0.10.0 -> 0.11.0
+
+### Fixed
+- [[#154]](https://github.com/rust-vmm/vhost/pull/154): Fix return value of GET_VRING_BASE message
+- [[#142]](https://github.com/rust-vmm/vhost/pull/142): vhost_user: Slave requests aren't only FS specific
+
 ## v0.8.0
 
 ### Added
-- [#120](https://github.com/rust-vmm/vhost/pull/120): vhost_kern: vdpa: Add missing ioctls
+- [[#120]](https://github.com/rust-vmm/vhost/pull/120): vhost_kern: vdpa: Add missing ioctls
 
 ### Changed
 - Updated dependency vhost 0.5 -> 0.6

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 libc = "0.2.39"
 log = "0.4.17"
-vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-slave"] }
+vhost = { path = "../vhost", version = "0.7", features = ["vhost-user-slave"] }
 virtio-bindings = "0.2.0"
 virtio-queue = "0.8.0"
 vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
@@ -19,6 +19,6 @@ vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 nix = "0.26"
-vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-master", "vhost-user-slave"] }
+vhost = { path = "../vhost", version = "0.7", features = ["vhost-user-master", "vhost-user-slave"] }
 vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -12,13 +12,13 @@ license = "Apache-2.0"
 libc = "0.2.39"
 log = "0.4.17"
 vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-slave"] }
-virtio-bindings = "0.1.0"
-virtio-queue = "0.7.0"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+virtio-bindings = "0.2.0"
+virtio-queue = "0.8.0"
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 nix = "0.26"
 vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-master", "vhost-user-slave"] }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -6,7 +6,21 @@
 ### Changed
 
 ### Fixed
+
+### Deprecated
+
+## [0.7.0]
+
+### Added
+- [[#137]](https://github.com/rust-vmm/vhost/pull/137) vhost_user: add Error::Disconnected
+
+### Changed
+- Updated dependency vm-memory 0.10.0 to 0.11.0
+
+### Fixed
 - [[#135]](https://github.com/rust-vmm/vhost/pull/135) vhost_user: fix UB on invalid master request
+- [[#136]](https://github.com/rust-vmm/vhost/pull/136) vhost_user: fix unsound send_message functions
+- [[#153]](https://github.com/rust-vmm/vhost/pull/153) Fix set_vring_addr issues
 
 ### Deprecated
 

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.6.0"
+version = "0.7.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -28,9 +28,9 @@ bitflags = "1.0"
 libc = "0.2.39"
 
 vmm-sys-util = "0.11.0"
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
-vm-memory = { version = "0.10.0", features=["backend-mmap"] }
+vm-memory = { version = "0.11.0", features=["backend-mmap"] }
 serial_test = "0.5"


### PR DESCRIPTION
Update deps to sync with the main rust-vmm crates (vm-memory, virtio-queue and virtio-bindings) and set up the stage to cut a new release.
