### PR TITLE
{vhost, vhost-user-backend}: Bulk update rust-vmm dependencies

### DIFF
--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -12,13 +12,13 @@ license = "Apache-2.0"
 libc = "0.2.39"
 log = "0.4.17"
 vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-slave"] }
-virtio-bindings = "0.1.0"
-virtio-queue = "0.7.0"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+virtio-bindings = "0.2.0"
+virtio-queue = "0.8.0"
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 nix = "0.26"
 vhost = { path = "../vhost", version = "0.6", features = ["vhost-user-master", "vhost-user-slave"] }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -28,9 +28,9 @@ bitflags = "1.0"
 libc = "0.2.39"
 
 vmm-sys-util = "0.11.0"
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
-vm-memory = { version = "0.10.0", features=["backend-mmap"] }
+vm-memory = { version = "0.11.0", features=["backend-mmap"] }
 serial_test = "0.5"


### PR DESCRIPTION
### Summary of the PR

This patch bumps `virtio-bindings` from 0.1.0 to 0.2.0, `virtio-queue` from 0.7.0 to 0.8.0, and `vm-memory` from 0.10.0 to 0.11.0.

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
