### PR TITLE
Xen/mmapv2

### DIFF
--- a/crates/vhost-user-backend/CHANGELOG.md
+++ b/crates/vhost-user-backend/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ### Deprecated
 
+## v0.10.0
+
+### Added
+- [[#169]](https://github.com/rust-vmm/vhost/pull/160) vhost-user-backend: Add support for Xen memory mappings
+
+### Fixed
+- [[#161]](https://github.com/rust-vmm/vhost/pull/161) get_vring_base should not reset the queue
+
 ## v0.9.0
 
 ### Added

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -8,17 +8,20 @@ repository = "https://github.com/rust-vmm/vhost"
 edition = "2018"
 license = "Apache-2.0"
 
+[features]
+xen = ["vm-memory/xen", "vhost/xen"]
+
 [dependencies]
 libc = "0.2.39"
 log = "0.4.17"
-vhost = { path = "../vhost", version = "0.7", features = ["vhost-user-slave"] }
-virtio-bindings = "0.2.0"
-virtio-queue = "0.8.0"
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
+vhost = { path = "../vhost", version = "0.8", features = ["vhost-user-slave"] }
+virtio-bindings = "0.2.1"
+virtio-queue = "0.9.0"
+vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 nix = "0.26"
-vhost = { path = "../vhost", version = "0.7", features = ["test-utils", "vhost-user-master", "vhost-user-slave"] }
-vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vhost = { path = "../vhost", version = "0.8", features = ["test-utils", "vhost-user-master", "vhost-user-slave"] }
+vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/crates/vhost-user-backend/README.md
+++ b/crates/vhost-user-backend/README.md
@@ -98,6 +98,18 @@ impl VhostUserBackendMut for VhostUserService {
 }
 ```
 
+## Xen support
+
+Supporting Xen requires special handling while mapping the guest memory. The
+`vm-memory` crate implements xen memory mapping support via a separate feature
+`xen`, and this crate uses the same feature name to enable Xen support.
+
+Also, for xen mappings, the memory regions passed by the frontend contains few
+extra fields as described in the vhost-user protocol documentation.
+
+It was decided by the `rust-vmm` maintainers to keep the interface simple and
+build the crate for either standard Unix memory mapping or Xen, and not both.
+
 ## License
 
 This project is licensed under

--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -6,9 +6,16 @@
 ### Changed
 
 ### Fixed
-- [[#165]](https://github.com/rust-vmm/vhost/pull/165) vhost: vdpa: Provide custom set_vring_addr() implementation
 
 ### Deprecated
+
+## [0.8.0]
+
+### Added
+- [[#169]](https://github.com/rust-vmm/vhost/pull/160) vhost: Add xen memory mapping support
+
+### Fixed
+- [[#165]](https://github.com/rust-vmm/vhost/pull/165) vhost: vdpa: Provide custom set_vring_addr() implementation
 
 ## [0.7.0]
 

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -23,15 +23,16 @@ vhost-net = ["vhost-kern"]
 vhost-user = []
 vhost-user-master = ["vhost-user"]
 vhost-user-slave = ["vhost-user"]
+xen = ["vm-memory/xen"]
 
 [dependencies]
 bitflags = "1.0"
 libc = "0.2.39"
 
 vmm-sys-util = "0.11.0"
-vm-memory = "0.11.0"
+vm-memory = "0.12.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
-vm-memory = { version = "0.11.0", features=["backend-mmap"] }
+vm-memory = { version = "0.12.0", features=["backend-mmap"] }
 serial_test = "0.5"

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.7.0"
+version = "0.8.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]

--- a/crates/vhost/README.md
+++ b/crates/vhost/README.md
@@ -30,3 +30,15 @@ The protocol defines two sides of the communication, master and slave.
 Master is the application that shares its virtqueues, slave is the consumer
 of the virtqueues. Master and slave can be either a client (i.e. connecting)
 or server (listening) in the socket communication.
+
+## Xen support
+
+Supporting Xen requires special handling while mapping the guest memory. The
+`vm-memory` crate implements xen memory mapping support via a separate feature
+`xen`, and this crate uses the same feature name to enable Xen support.
+
+Also, for xen mappings, the memory regions passed by the frontend contains few
+extra fields as described in the vhost-user protocol documentation.
+
+It was decided by the `rust-vmm` maintainers to keep the interface simple and
+build the crate for either standard Unix memory mapping or Xen, and not both.

--- a/crates/vhost/src/vhost_user/message.rs
+++ b/crates/vhost/src/vhost_user/message.rs
@@ -10,10 +10,15 @@
 #![allow(clippy::upper_case_acronyms)]
 
 use std::fmt::Debug;
+use std::fs::File;
+use std::io;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
-use vm_memory::ByteValued;
+use vm_memory::{mmap::NewBitmap, ByteValued, Error as MmapError, FileOffset, MmapRegion};
+
+#[cfg(feature = "xen")]
+use vm_memory::{GuestAddress, MmapRange, MmapXenFlags};
 
 use super::{Error, Result};
 use crate::VringConfigData;
@@ -422,6 +427,8 @@ bitflags! {
         const CONFIGURE_MEM_SLOTS = 0x0000_8000;
         /// Support reporting status.
         const STATUS = 0x0001_0000;
+        /// Support Xen mmap.
+        const XEN_MMAP = 0x0002_0000;
     }
 }
 
@@ -492,8 +499,26 @@ pub struct VhostUserMemoryRegion {
     pub user_addr: u64,
     /// Offset where region starts in the mapped memory.
     pub mmap_offset: u64,
+
+    #[cfg(feature = "xen")]
+    /// Xen specific flags.
+    pub xen_mmap_flags: u32,
+
+    #[cfg(feature = "xen")]
+    /// Xen specific data.
+    pub xen_mmap_data: u32,
 }
 
+impl VhostUserMemoryRegion {
+    fn is_valid_common(&self) -> bool {
+        self.memory_size != 0
+            && self.guest_phys_addr.checked_add(self.memory_size).is_some()
+            && self.user_addr.checked_add(self.memory_size).is_some()
+            && self.mmap_offset.checked_add(self.memory_size).is_some()
+    }
+}
+
+#[cfg(not(feature = "xen"))]
 impl VhostUserMemoryRegion {
     /// Create a new instance.
     pub fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
@@ -504,18 +529,74 @@ impl VhostUserMemoryRegion {
             mmap_offset,
         }
     }
+
+    /// Creates mmap region from Self.
+    pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<MmapRegion<B>> {
+        MmapRegion::<B>::from_file(
+            FileOffset::new(file, self.mmap_offset),
+            self.memory_size as usize,
+        )
+        .map_err(MmapError::MmapRegion)
+        .map_err(|e| Error::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e)))
+    }
+
+    fn is_valid(&self) -> bool {
+        self.is_valid_common()
+    }
+}
+
+#[cfg(feature = "xen")]
+impl VhostUserMemoryRegion {
+    /// Create a new instance.
+    pub fn with_xen(
+        guest_phys_addr: u64,
+        memory_size: u64,
+        user_addr: u64,
+        mmap_offset: u64,
+        xen_mmap_flags: u32,
+        xen_mmap_data: u32,
+    ) -> Self {
+        VhostUserMemoryRegion {
+            guest_phys_addr,
+            memory_size,
+            user_addr,
+            mmap_offset,
+            xen_mmap_flags,
+            xen_mmap_data,
+        }
+    }
+
+    /// Creates mmap region from Self.
+    pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<MmapRegion<B>> {
+        let range = MmapRange::new(
+            self.memory_size as usize,
+            Some(FileOffset::new(file, self.mmap_offset)),
+            GuestAddress(self.guest_phys_addr),
+            self.xen_mmap_flags,
+            self.xen_mmap_data,
+        );
+
+        MmapRegion::<B>::from_range(range)
+            .map_err(MmapError::MmapRegion)
+            .map_err(|e| Error::ReqHandlerError(io::Error::new(io::ErrorKind::Other, e)))
+    }
+
+    fn is_valid(&self) -> bool {
+        if !self.is_valid_common() {
+            false
+        } else {
+            // Only of one of FOREIGN or GRANT should be set.
+            match MmapXenFlags::from_bits(self.xen_mmap_flags) {
+                Some(flags) => flags.is_valid(),
+                None => false,
+            }
+        }
+    }
 }
 
 impl VhostUserMsgValidator for VhostUserMemoryRegion {
     fn is_valid(&self) -> bool {
-        if self.memory_size == 0
-            || self.guest_phys_addr.checked_add(self.memory_size).is_none()
-            || self.user_addr.checked_add(self.memory_size).is_none()
-            || self.mmap_offset.checked_add(self.memory_size).is_none()
-        {
-            return false;
-        }
-        true
+        self.is_valid()
     }
 }
 
@@ -541,6 +622,7 @@ impl Deref for VhostUserSingleMemoryRegion {
     }
 }
 
+#[cfg(not(feature = "xen"))]
 impl VhostUserSingleMemoryRegion {
     /// Create a new instance.
     pub fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
@@ -551,6 +633,31 @@ impl VhostUserSingleMemoryRegion {
                 memory_size,
                 user_addr,
                 mmap_offset,
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "xen")]
+impl VhostUserSingleMemoryRegion {
+    /// Create a new instance.
+    pub fn new(
+        guest_phys_addr: u64,
+        memory_size: u64,
+        user_addr: u64,
+        mmap_offset: u64,
+        xen_mmap_flags: u32,
+        xen_mmap_data: u32,
+    ) -> Self {
+        VhostUserSingleMemoryRegion {
+            padding: 0,
+            region: VhostUserMemoryRegion::with_xen(
+                guest_phys_addr,
+                memory_size,
+                user_addr,
+                mmap_offset,
+                xen_mmap_flags,
+                xen_mmap_data,
             ),
         }
     }
@@ -1001,6 +1108,20 @@ mod tests {
     use super::*;
     use std::mem;
 
+    #[cfg(feature = "xen")]
+    impl VhostUserMemoryRegion {
+        fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
+            Self::with_xen(
+                guest_phys_addr,
+                memory_size,
+                user_addr,
+                mmap_offset,
+                MmapXenFlags::FOREIGN.bits(),
+                0,
+            )
+        }
+    }
+
     #[test]
     fn check_master_request_code() {
         assert!(!MasterReq::is_valid(MasterReq::NOOP as _));
@@ -1106,12 +1227,7 @@ mod tests {
 
     #[test]
     fn check_user_memory_region() {
-        let mut msg = VhostUserMemoryRegion {
-            guest_phys_addr: 0,
-            memory_size: 0x1000,
-            user_addr: 0,
-            mmap_offset: 0,
-        };
+        let mut msg = VhostUserMemoryRegion::new(0, 0x1000, 0, 0);
         assert!(msg.is_valid());
         msg.guest_phys_addr = 0xFFFFFFFFFFFFEFFF;
         assert!(msg.is_valid());

--- a/crates/vhost/src/vhost_user/mod.rs
+++ b/crates/vhost/src/vhost_user/mod.rs
@@ -345,9 +345,17 @@ mod tests {
 
             slave.handle_request().unwrap();
             slave.handle_request().unwrap();
+
+            let mut features = VhostUserProtocolFeatures::all();
+
+            // Disable Xen mmap feature.
+            if !cfg!(feature = "xen") {
+                features.remove(VhostUserProtocolFeatures::XEN_MMAP);
+            }
+
             assert_eq!(
                 slave_be.lock().unwrap().acked_protocol_features,
-                VhostUserProtocolFeatures::all().bits()
+                features.bits()
             );
 
             // get_inflight_fd()
@@ -403,8 +411,14 @@ mod tests {
         master.set_features(VIRTIO_FEATURES & !0x1).unwrap();
 
         // set vhost protocol features
-        let features = master.get_protocol_features().unwrap();
+        let mut features = master.get_protocol_features().unwrap();
         assert_eq!(features.bits(), VhostUserProtocolFeatures::all().bits());
+
+        // Disable Xen mmap feature.
+        if !cfg!(feature = "xen") {
+            features.remove(VhostUserProtocolFeatures::XEN_MMAP);
+        }
+
         master.set_protocol_features(features).unwrap();
 
         // Retrieve inflight I/O tracking information

--- a/crates/vhost/src/vhost_user/slave_req_handler.rs
+++ b/crates/vhost/src/vhost_user/slave_req_handler.rs
@@ -432,6 +432,9 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                 self.acked_protocol_features = msg.value;
                 self.update_reply_ack_flag();
                 self.send_ack_message(&hdr, res)?;
+
+                #[cfg(feature = "xen")]
+                self.check_proto_feature(VhostUserProtocolFeatures::XEN_MMAP)?;
             }
             Ok(MasterReq::GET_QUEUE_NUM) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::MQ)?;

--- a/crates/vhost/src/vhost_user/slave_req_handler.rs
+++ b/crates/vhost/src/vhost_user/slave_req_handler.rs
@@ -421,6 +421,11 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
             Ok(MasterReq::GET_PROTOCOL_FEATURES) => {
                 self.check_request_size(&hdr, size, 0)?;
                 let features = self.backend.get_protocol_features()?;
+
+                // Enable the `XEN_MMAP` protocol feature for backends if xen feature is enabled.
+                #[cfg(feature = "xen")]
+                let features = features | VhostUserProtocolFeatures::XEN_MMAP;
+
                 let msg = VhostUserU64::new(features.bits());
                 self.send_reply_message(&hdr, &msg)?;
                 self.protocol_features = features;


### PR DESCRIPTION
vhost: Add support for generic memory mappings
    
vm-memory crate now supports Xen specific memory mappings via a special
feature: "xen". Modify all vhost crates to work with the new feature.
    
Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
