### PR TITLE
vhost: vdpa: Provide custom `set_vring_addr()` implementation

### DIFF
--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- [[#165]](https://github.com/rust-vmm/vhost/pull/165) vhost: vdpa: Provide custom set_vring_addr() implementation
 
 ### Deprecated
 


### PR DESCRIPTION
### Summary of the PR

Unlike other vhost backends (e.g. vhost-net and vhost-vsock), vDPA
backends can not work with host virtual address (HVA), instead they
expect I/O virtual address (IOVA). The IOVA can be mapped 1:1 with
guest physical address (GPA) when no IOMMU is involved. This is why
the default implementation of `set_vring_addr()` from Trait
`VhostBackend` is no longer working with vDPA backends. To solve this
issue, this patch provides a custom `set_vring_addr()` implementation
for Trait `VhostKernVdpa`.

Fixes: #164

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
