### PR TITLE
Convenience function to listen + accept + wait + exit

### DIFF
--- a/crates/vhost-user-backend/CHANGELOG.md
+++ b/crates/vhost-user-backend/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#173]](https://github.com/rust-vmm/vhost/pull/173) vhost-user-backend: Added convenience function `serve`
 
 ### Changed
 - Change uses of master/slave for frontend/backend in the codebase.

--- a/crates/vhost-user-backend/src/backend.rs
+++ b/crates/vhost-user-backend/src/backend.rs
@@ -93,9 +93,8 @@ where
 
     /// Provide an optional exit EventFd for the specified worker thread.
     ///
-    /// If an (`EventFd`, `token`) pair is returned, the returned `EventFd` will be monitored for IO
-    /// events by using epoll with the specified `token`. When the returned EventFd is written to,
-    /// the worker thread will exit.
+    /// The returned `EventFd` will be monitored for IO events. When the
+    /// returned EventFd is written to, the worker thread will exit.
     fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
         None
     }

--- a/crates/vhost-user-backend/src/lib.rs
+++ b/crates/vhost-user-backend/src/lib.rs
@@ -211,8 +211,7 @@ mod tests {
 
         let barrier = Arc::new(Barrier::new(2));
         let tmpdir = tempfile::tempdir().unwrap();
-        let mut path = tmpdir.path().to_path_buf();
-        path.push("socket");
+        let path = tmpdir.path().join("socket");
 
         let barrier2 = barrier.clone();
         let path1 = path.clone();
@@ -246,8 +245,7 @@ mod tests {
 
         let barrier = Arc::new(Barrier::new(2));
         let tmpdir = tempfile::tempdir().unwrap();
-        let mut path = tmpdir.path().to_path_buf();
-        path.push("socket");
+        let path = tmpdir.path().join("socket");
 
         let barrier2 = barrier.clone();
         let path1 = path.clone();


### PR DESCRIPTION
### Summary of the PR

We figured that all vhost-device daemons just ended up copying code from
each other. During an earlier attempt to solve that with a helper crate
for vhost-device [1], it was suggested to extend the vhost-user-backend
API directly. This way more people can benefit from this.

[1] https://github.com/rust-vmm/vhost-device/pull/362

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
