### PR TITLE
vhost: Always enable vm-memory/backend-mmap

### DIFF
--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -30,9 +30,8 @@ bitflags = "1.0"
 libc = "0.2.39"
 
 vmm-sys-util = "0.11.0"
-vm-memory = "0.12.0"
+vm-memory = { version = "0.12.0", features=["backend-mmap"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"
-vm-memory = { version = "0.12.0", features=["backend-mmap"] }
 serial_test = "0.5"


### PR DESCRIPTION
Since 4029089f ('vhost: Add support for Xen memory mappings') the feature backend-mmap of the vm-memory crate is no longer just a dev-dependency. Make it a formal dependency.
