### PR TITLE
vhost: Release v0.8.1

### DIFF
--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ### Deprecated
 
+## [0.8.1]
+
+### Fixed
+- [[#175]](https://github.com/rust-vmm/vhost/pull/175) vhost: Always enable vm-memory/backend-mmap
+
 ## [0.8.0]
 
 ### Added


### PR DESCRIPTION
We experienced a small dependency issue with the `vm-memory` crate features, let's release this version to fix it.