### PR TITLE
vhost: update release v0.8.1 in Cargo.toml

### DIFF
--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.8.0"
+version = "0.8.1"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
In the previous commit I forgot to update the version in vhost/Cargo.toml, let's set it to 0.8.1
