### PR TITLE
Fix set_vring_addr issues and release vhost v0.6.1

### DIFF
--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Deprecated
 
+## [0.6.1]
+
+### Fixed
+- [[#182]](https://github.com/rust-vmm/vhost/pull/182) Fix set_vring_addr
+  issues & vhost: vdpa: Provide custom set_vring_addr() implementation
+
 ## [0.6.0]
 
 ### Upgraded

--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- [[#165]](https://github.com/rust-vmm/vhost/pull/165) vhost: vdpa: Provide custom set_vring_addr() implementation
 
 ### Deprecated
 

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.6.0"
+version = "0.6.1"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
### Summary of the PR

#### Prepare to release vhost v0.6.1

Update `CHANGLOG.md` for this release.

#### Cherry-pick from bdc6f2ab2b3dbd3b9574100ac641a2f8e9667400

Unlike other vhost backends (e.g. vhost-net and vhost-vsock), vDPA
backends can not work with host virtual address (HVA), instead they
expect I/O virtual address (IOVA). The IOVA can be mapped 1:1 with
guest physical address (GPA) when no IOMMU is involved. This is why
the default implementation of `set_vring_addr()` from Trait
`VhostBackend` is no longer working with vDPA backends. To solve this
issue, this patch provides a custom `set_vring_addr()` implementation
for Trait `VhostKernVdpa`.

Fixes: #164

Signed-off-by: Bo Chen <chen.bo@intel.com>

#### Cherry-pick from 7e76859b3e272e64bd31cd0a63a8709c6efdfc4f

`VhostBackend::set_vring_addr()` receives a vring config data which
contains the addresses of desc table, used ring and avail ring.
`VhostBackend::is_valid()` checks the addresses in the guest address space.
`VHOST_SET_VRING_ADDR` uses the addresses in the host address space.
However, the method doesn't convert those addresses. 

To address this issue, the addresses passed by the config are checked in
the guest address space. Then, they are converted by
`VringConfigData::to_vhost_vring_addr()` into the host address space to
setup the vring on the kernel. 

Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
