### PR TITLE
vhost-user-backend: release v0.10.1

### DIFF
--- a/crates/vhost-user-backend/CHANGELOG.md
+++ b/crates/vhost-user-backend/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ### Deprecated
 
+## v0.10.1
+
+### Fixed
+- [[#180]](https://github.com/rust-vmm/vhost/pull/180) vhost-user-backend: fetch 'used' index from guest
+
 ## v0.10.0
 
 ### Added

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"


### PR DESCRIPTION
Commit 8a4ba9d ("vhost-user-backend: fetch 'used' index from guest") fixes an issue introduced in v0.10.0 that affects all vhost-user backends like virtiofsd [1] or rust-vmm's vhost-device. I easily reproduced the problem with vhost-device-vsock as well: just restart the guest kernel and the device no longer works.

[1] https://gitlab.com/virtio-fs/virtiofsd/-/issues/120
