### PR TITLE
Safety fixes

### DIFF
--- a/crates/vhost/src/vhost_user/message.rs
+++ b/crates/vhost/src/vhost_user/message.rs
@@ -203,7 +203,7 @@ impl Req for SlaveReq {
 }
 
 /// Vhost message Validator.
-pub trait VhostUserMsgValidator {
+pub trait VhostUserMsgValidator: ByteValued {
     /// Validate message syntax only.
     /// It doesn't validate message semantics such as protocol version number and dependency
     /// on feature flags etc.
@@ -593,6 +593,9 @@ impl VhostUserMemoryRegion {
         }
     }
 }
+
+// SAFETY: Safe because all fields of VhostUserMemoryRegion are POD.
+unsafe impl ByteValued for VhostUserMemoryRegion {}
 
 impl VhostUserMsgValidator for VhostUserMemoryRegion {
     fn is_valid(&self) -> bool {


### PR DESCRIPTION
This code is currently unsound as it initializes an `&[u8]` that points to potential padding bytes.

https://github.com/rust-vmm/vhost/blob/6ca88e160a8d34be54a158cc1bc702e9250e97dd/crates/vhost/src/vhost_user/master.rs#L202

`repr(C)` would also work though it is brittle if the struct is change in the future, happy to switch over.


I also marked `VhostUserMsgValidator` as requiring `ByteValued` since `extract_request_body` assumes these types are POD.

https://github.com/rust-vmm/vhost/blob/6ca88e160a8d34be54a158cc1bc702e9250e97dd/crates/vhost/src/vhost_user/slave_req_handler.rs#L728