### PR TITLE
vhost-user-backend: remove return value from handle_event

### DIFF
--- a/crates/vhost-user-backend/CHANGELOG.md
+++ b/crates/vhost-user-backend/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Change uses of master/slave for frontend/backend in the codebase.
+- [[#192]](https://github.com/rust-vmm/vhost/pull/192) vhost-user-backend: remove return value from handle_event
 
 ### Fixed
 

--- a/crates/vhost-user-backend/src/backend.rs
+++ b/crates/vhost-user-backend/src/backend.rs
@@ -110,7 +110,7 @@ where
         evset: EventSet,
         vrings: &[V],
         thread_id: usize,
-    ) -> Result<bool>;
+    ) -> Result<()>;
 }
 
 /// Trait without interior mutability for vhost user backend servers to implement concrete services.
@@ -191,7 +191,7 @@ where
         evset: EventSet,
         vrings: &[V],
         thread_id: usize,
-    ) -> Result<bool>;
+    ) -> Result<()>;
 }
 
 impl<T: VhostUserBackend<V, B>, V, B> VhostUserBackend<V, B> for Arc<T>
@@ -253,7 +253,7 @@ where
         evset: EventSet,
         vrings: &[V],
         thread_id: usize,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         self.deref()
             .handle_event(device_event, evset, vrings, thread_id)
     }
@@ -318,7 +318,7 @@ where
         evset: EventSet,
         vrings: &[V],
         thread_id: usize,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         self.lock()
             .unwrap()
             .handle_event(device_event, evset, vrings, thread_id)
@@ -384,7 +384,7 @@ where
         evset: EventSet,
         vrings: &[V],
         thread_id: usize,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         self.write()
             .unwrap()
             .handle_event(device_event, evset, vrings, thread_id)
@@ -491,10 +491,10 @@ pub mod tests {
             _evset: EventSet,
             _vrings: &[VringRwLock],
             _thread_id: usize,
-        ) -> Result<bool> {
+        ) -> Result<()> {
             self.events += 1;
 
-            Ok(false)
+            Ok(())
         }
     }
 

--- a/crates/vhost-user-backend/src/event_loop.rs
+++ b/crates/vhost-user-backend/src/event_loop.rs
@@ -211,7 +211,9 @@ where
 
         self.backend
             .handle_event(device_event, evset, &self.vrings, self.thread_id)
-            .map_err(VringEpollError::HandleEventBackendHandling)
+            .map_err(VringEpollError::HandleEventBackendHandling)?;
+
+        Ok(false)
     }
 }
 

--- a/crates/vhost-user-backend/tests/vhost-user-server.rs
+++ b/crates/vhost-user-backend/tests/vhost-user-server.rs
@@ -99,10 +99,10 @@ impl VhostUserBackendMut<VringRwLock, ()> for MockVhostBackend {
         _evset: EventSet,
         _vrings: &[VringRwLock],
         _thread_id: usize,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         self.events += 1;
 
-        Ok(false)
+        Ok(())
     }
 }
 


### PR DESCRIPTION
### Summary of the PR

The return value of VhostUserBackend::handle_event() is undocumented and difficult to interpret.
The current implementation used it to interrupt the event loop as it does when we receive an exit event.

All current implementations checked (rust-vmm/vhost-device, virtiofsd) return an error or always false, effectively not using this feature.

Since we already have a mechanism for breaking the event loop, we can avoid this ambiguous and redundant feature.

Closes #144

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
