### PR TITLE
New releases: vhost v0.9.0 and vhost-user-backend v0.11.0

### DIFF
--- a/crates/vhost-user-backend/CHANGELOG.md
+++ b/crates/vhost-user-backend/CHANGELOG.md
@@ -2,17 +2,25 @@
 ## [Unreleased]
 
 ### Added
-- [[#173]](https://github.com/rust-vmm/vhost/pull/173) vhost-user-backend: Added convenience function `serve`
 
 ### Changed
-- Change uses of master/slave for frontend/backend in the codebase.
-- [[#192]](https://github.com/rust-vmm/vhost/pull/192) vhost-user-backend: remove return value from handle_event
-- [[#155]](https://github.com/rust-vmm/vhost/pull/155) Converted generic type
-  parameters of VhostUserBackend into associated types.
 
 ### Fixed
 
 ### Deprecated
+
+## v0.11.0
+
+### Added
+- [[#173]](https://github.com/rust-vmm/vhost/pull/173) vhost-user-backend: Added convenience function `serve`
+
+### Changed
+- [[#187]](https://github.com/rust-vmm/vhost/pull/187) Clean master slave
+  - Replaced master/slave with frontend/backend in the codebase and public API.
+- [[#192]](https://github.com/rust-vmm/vhost/pull/192) vhost-user-backend: remove return value from handle_event
+- [[#155]](https://github.com/rust-vmm/vhost/pull/155) Converted generic type
+  parameters of VhostUserBackend into associated types.
+- [[#116]](https://github.com/rust-vmm/vhost/pull/116) Upgrade to 2021 edition
 
 ## v0.10.1
 

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"

--- a/crates/vhost-user-backend/Cargo.toml
+++ b/crates/vhost-user-backend/Cargo.toml
@@ -14,7 +14,7 @@ xen = ["vm-memory/xen", "vhost/xen"]
 [dependencies]
 libc = "0.2.39"
 log = "0.4.17"
-vhost = { path = "../vhost", version = "0.8", features = ["vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.9", features = ["vhost-user-backend"] }
 virtio-bindings = "0.2.1"
 virtio-queue = "0.10.0"
 vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
@@ -22,6 +22,6 @@ vmm-sys-util = "0.11.0"
 
 [dev-dependencies]
 nix = { version = "0.27", features = ["fs"] }
-vhost = { path = "../vhost", version = "0.8", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.9", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
 vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/crates/vhost/CHANGELOG.md
+++ b/crates/vhost/CHANGELOG.md
@@ -4,11 +4,23 @@
 ### Added
 
 ### Changed
-- Change uses of master/slave for frontend/backend in the codebase.
 
 ### Fixed
 
 ### Deprecated
+
+## [0.9.0]
+
+### Changed
+- [[#187]](https://github.com/rust-vmm/vhost/pull/187) Clean master slave
+  - Replaced master/slave with frontend/backend in the codebase and public API.
+  - Replaced master/slave with frontend/backend in the crate features.
+- Updated dependency bitflags from 1.0 to 2.4
+- [[#116]](https://github.com/rust-vmm/vhost/pull/116) Upgrade to 2021 edition
+
+### Fixed
+- [[#184]](https://github.com/rust-vmm/vhost/pull/184) Safety fixes
+- [[#186]](https://github.com/rust-vmm/vhost/pull/186) vhost: Fix clippy warnings.
 
 ## [0.8.1]
 

--- a/crates/vhost/Cargo.toml
+++ b/crates/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.8.1"
+version = "0.9.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
### Summary of the PR

Preparation for a new release for both `vhost` and `vhost-user-backend`

I also run semver-checks:
```
$ cargo semver-checks check-release
     Parsing vhost v0.9.0 (current)
     Parsing vhost v0.8.1 (baseline)
    Checking vhost v0.8.1 -> v0.9.0 (major change)
   Completed [   0.000s] 0 checks; 0 passed, 48 unnecessary
     Parsing vhost-user-backend v0.11.0 (current)
     Parsing vhost-user-backend v0.10.1 (baseline)
    Checking vhost-user-backend v0.10.1 -> v0.11.0 (major change)
   Completed [   0.000s] 0 checks; 0 passed, 48 unnecessary
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
