### PR TITLE
workspace: specify `workspace.resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "crates/vhost",


### PR DESCRIPTION
After updating rust edition to 2021, cargo complains about the resolver:

    warning: some crates are on edition 2021 which defaults to
    `resolver = "2"`, but virtual workspaces default to
    `resolver = "1"`
    note: to keep the current resolver, specify
    `workspace.resolver = "1"` in the workspace root's manifest
    note: to use the edition 2021 resolver, specify
    `workspace.resolver = "2"` in the workspace root's manifest

Let's specify to use the edition 2021 resolver.
