### PR TITLE
dependabot: enable update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 3
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+  groups:
+      vhost:
+        patterns:
+          - "*"
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:


### PR DESCRIPTION
This was tested on vhost-device successfully [1]. Lets enable it here!

[1] https://github.com/rust-vmm/vhost-device/commit/072fadaaba527133c3466cac90a8c5dd386b1f9e

Suggested-by: Patrick Roy <roypat@amazon.co.uk>
Suggested-by: Stefano Garzarella <sgarzare@redhat.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- na All added/changed functionality has a corresponding unit/integration
  test.
- na All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- na Any newly added `unsafe` code is properly documented.
