### PR TITLE
Add back-end's internal state migration support

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 75.0,
+  "coverage_score": 72.12,
   "exclude_path": "vhost/src/vhost_kern/",
   "crate_features": "vhost/vhost-user-frontend,vhost/vhost-user-backend"
 }

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 use std::thread;
 
 use vhost::vhost_user::message::{
-    VhostUserConfigFlags, VhostUserMemoryRegion, VhostUserProtocolFeatures,
-    VhostUserSingleMemoryRegion, VhostUserVirtioFeatures, VhostUserVringAddrFlags,
-    VhostUserVringState,
+    VhostTransferStateDirection, VhostTransferStatePhase, VhostUserConfigFlags,
+    VhostUserMemoryRegion, VhostUserProtocolFeatures, VhostUserSingleMemoryRegion,
+    VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
 };
 use vhost::vhost_user::{
     Backend, Error as VhostUserError, Result as VhostUserResult, VhostUserBackendReqHandlerMut,
@@ -616,6 +616,23 @@ where
             .retain(|mapping| mapping.gpa_base != region.guest_phys_addr);
 
         Ok(())
+    }
+
+    fn set_device_state_fd(
+        &mut self,
+        direction: VhostTransferStateDirection,
+        phase: VhostTransferStatePhase,
+        file: File,
+    ) -> VhostUserResult<Option<File>> {
+        self.backend
+            .set_device_state_fd(direction, phase, file)
+            .map_err(VhostUserError::ReqHandlerError)
+    }
+
+    fn check_device_state(&mut self) -> VhostUserResult<()> {
+        self.backend
+            .check_device_state()
+            .map_err(VhostUserError::ReqHandlerError)
     }
 }
 

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -291,4 +291,23 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
     fn remove_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion) -> Result<()> {
         Ok(())
     }
+
+    fn set_device_state_fd(
+        &mut self,
+        _direction: VhostTransferStateDirection,
+        _phase: VhostTransferStatePhase,
+        _fd: File,
+    ) -> Result<Option<File>> {
+        Err(Error::ReqHandlerError(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "dummy back end does not support state transfer",
+        )))
+    }
+
+    fn check_device_state(&mut self) -> Result<()> {
+        Err(Error::ReqHandlerError(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "dummy back end does not support state transfer",
+        )))
+    }
 }

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -440,6 +440,8 @@ bitflags! {
         const STATUS = 0x0001_0000;
         /// Support Xen mmap.
         const XEN_MMAP = 0x0002_0000;
+        /// Support transferring internal device state.
+        const DEVICE_STATE = 0x0008_0000;
     }
 }
 


### PR DESCRIPTION
### Summary of the PR
  
A new set of messages have been introduced in the vhost-user protocol to support the migration of devices with back-end's internal state[0].
    
These are the additions to the protocol:
    - New vhost-user protocol feature `VHOST_USER_PROTOCOL_F_DEVICE_STATE`
    - `SET_DEVICE_STATE_FD` function: Front-end and back-end negotiate a file
      descriptor over which to transfer the state. It also includes
      establishing the direction of transfer and migration phase.
    - `CHECK_DEVICE_STATE`: After the state has been transferred through the
      file descriptor, the front-end invokes this function to verify
      success.  There is no in-band way (through the file descriptor) to
      indicate failure, so we need to check explicitly.
    
[0] https://github.com/qemu/qemu/commit/019233096c03b826e0e677115b6e3c550a54a48d

This code is part of the effort to support live migration in virtiofsd and is currently being used in a version of virtiofsd that supports migration: https://gitlab.com/virtiofsd-live-migration

### Note to reviewers

~Please do not merge this PR yet, this PR depends on https://github.com/rust-vmm/vhost/pull/202, because by adding `FrontendReq::SET_DEVICE_STATE_FD` a "hole" was created in value `41`, this makes the APi unsound, since `VhostUserMsgHeader::get_code()` call `transmute_copy()` which assumes that the values are continuous and have no "holes" between them.~

~I'll rebase and adjust the code after PR 202 gets merged.~
