### PR TITLE
vhost_user: Remove commented code

### DIFF
--- a/crates/vhost/src/vhost_user/message.rs
+++ b/crates/vhost/src/vhost_user/message.rs
@@ -907,32 +907,6 @@ impl VhostUserMsgValidator for VhostUserLog {
     }
 }
 
-/*
- * TODO: support dirty log, live migration and IOTLB operations.
-#[repr(packed)]
-pub struct VhostUserVringArea {
-    pub index: u32,
-    pub flags: u32,
-    pub size: u64,
-    pub offset: u64,
-}
-
-#[repr(packed)]
-pub struct VhostUserLog {
-    pub size: u64,
-    pub offset: u64,
-}
-
-#[repr(packed)]
-pub struct VhostUserIotlb {
-    pub iova: u64,
-    pub size: u64,
-    pub user_addr: u64,
-    pub permission: u8,
-    pub optype: u8,
-}
-*/
-
 // Bit mask for flags in virtio-fs backend messages
 bitflags! {
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]


### PR DESCRIPTION
### Summary of the PR

Let's remove commented vhost-user message definitions, some of the message definition are not supported and the other is duplicated (i.e., VhostUserLog is already defined).

### Note to reviewers
I think we also need to remove the following back-end message types:

```rust
pub enum BackendReq {
    ...
    /// Virtio-fs draft: map file content into the window.
    FS_MAP = 6,
    /// Virtio-fs draft: unmap file content from the window.
    FS_UNMAP = 7,
    /// Virtio-fs draft: sync file content.
    FS_SYNC = 8,
    /// Virtio-fs draft: perform a read/write from an fd directly to GPA.
    FS_IO = 9,
    ...
}
```

These are not in the vhost-user standard, which in itself is confusing, but even conflict with values that are defined in the standard (see  [Back-end message types](https://qemu-project.gitlab.io/qemu/interop/vhost-user.html#id37)), such as: `VHOST_USER_BACKEND_SHARED_OBJECT_ADD`, `VHOST_USER_BACKEND_SHARED_OBJECT_REMOVE` and `VHOST_USER_BACKEND_SHARED_OBJECT_LOOKUP`.

I have not removed them (yet) because there is not only the definition but also part of the API implemented in the `FrontendReqHandler` and in `Backend`.
