### PR TITLE
vhost-user-backend: check `index` in set_vring_base()

### DIFF
--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -369,6 +369,10 @@ where
     }
 
     fn set_vring_base(&mut self, index: u32, base: u32) -> VhostUserResult<()> {
+        if index as usize >= self.num_queues {
+            return Err(VhostUserError::InvalidParam);
+        }
+
         let event_idx: bool = (self.acked_features & (1 << VIRTIO_RING_F_EVENT_IDX)) != 0;
 
         self.vrings[index as usize].set_queue_next_avail(base as u16);


### PR DESCRIPTION
VHostUserHandler::set_vring_base() lacks validation of the input parameter `index`, which is used for indexing an internal vector and could potentially lead to a Out-of-Bounds write resulting in a panic.

Closes #211
