### PR TITLE
vhost-user-backend: take reference to `vring` once

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 76.3,
+  "coverage_score": 75.0,
   "exclude_path": "vhost/src/vhost_kern/",
   "crate_features": "vhost/vhost-user-frontend,vhost/vhost-user-backend"
 }


### PR DESCRIPTION
vhost-user-backend: take reference to `vring` once
    
In many places we access the `VhostUserHandler::vrings` array many
times and at the beginning of each function we check the index to
avoid OOB.
    
It happened that we forgot about this check (see #211), so let's
avoid this error-prone pattern by taking the reference to the vring
using `Vec::get()`, and avoiding multiple indexing.
    
Suggested-by: Erik Schilling <erik.schilling@linaro.org>
Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>