### PR TITLE
Adding POSTCOPY support

### DIFF
--- a/.buildkite/rust-vmm-ci-tests.json
+++ b/.buildkite/rust-vmm-ci-tests.json
@@ -30,7 +30,7 @@
     },
     {
       "test_name": "unittests-gnu-all-without-xen",
-      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"
@@ -46,7 +46,7 @@
     },
     {
       "test_name": "unittests-musl-all-without-xen",
-      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"
@@ -62,7 +62,7 @@
     },
     {
       "test_name": "clippy-all-without-xen",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
         "aarch64"
@@ -78,7 +78,7 @@
     },
     {
       "test_name": "check-warnings-all-without-xen",
-      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 72.12,
   "exclude_path": "vhost/src/vhost_kern/",
-  "crate_features": "vhost/vhost-user-frontend,vhost/vhost-user-backend"
+  "crate_features": "vhost/vhost-user-frontend,vhost/vhost-user-backend,vhost-user-backend/postcopy"
 }

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -10,10 +10,12 @@ license = "Apache-2.0"
 
 [features]
 xen = ["vm-memory/xen", "vhost/xen"]
+postcopy = ["vhost/postcopy", "userfaultfd"]
 
 [dependencies]
 libc = "0.2.39"
 log = "0.4.17"
+userfaultfd = { version = "0.7.0", optional = true }
 vhost = { path = "../vhost", version = "0.10", features = ["vhost-user-backend"] }
 virtio-bindings = "0.2.1"
 virtio-queue = "0.11.0"

--- a/vhost-user-backend/README.md
+++ b/vhost-user-backend/README.md
@@ -98,6 +98,16 @@ impl VhostUserBackendMut for VhostUserService {
 }
 ```
 
+## Postcopy support
+
+To enabled POSTCOPY_* messages support there is a `postcopy` feature.
+Due to how Xen handles memory mappings the `postcopy` feature is not compatible
+with `xen` feature. Enabling both at the same time will result in a compilation error.
+
+`postcopy` feature enables optional `userfaultfd` dependency in order to create and
+interact with `userfaultfd` object. This requires access permission to `/dev/userfaultfd`
+file from the backend.
+
 ## Xen support
 
 Supporting Xen requires special handling while mapping the guest memory. The

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -33,6 +33,12 @@ pub use self::vring::{
     VringMutex, VringRwLock, VringState, VringStateGuard, VringStateMutGuard, VringT,
 };
 
+/// Due to the way `xen` handles memory mappings we can not combine it with
+/// `postcopy` feature which relies on persistent memory mappings. Thus we
+/// disallow enabling both features at the same time.
+#[cfg(all(feature = "postcopy", feature = "xen"))]
+compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
+
 /// An alias for `GuestMemoryAtomic<GuestMemoryMmap<B>>` to simplify code.
 type GM<B> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
 

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -292,3 +292,34 @@ fn vhost_user_get_inflight(path: &Path, barrier: Arc<Barrier>) {
 fn test_vhost_user_get_inflight() {
     vhost_user_server(vhost_user_get_inflight);
 }
+
+#[cfg(feature = "postcopy")]
+fn vhost_user_postcopy_advise(path: &Path, barrier: Arc<Barrier>) {
+    let mut frontend = setup_frontend(path, barrier);
+    let _uffd_file = frontend.postcopy_advise().unwrap();
+}
+
+#[cfg(feature = "postcopy")]
+fn vhost_user_postcopy_listen(path: &Path, barrier: Arc<Barrier>) {
+    let mut frontend = setup_frontend(path, barrier);
+    let _uffd_file = frontend.postcopy_advise().unwrap();
+    frontend.postcopy_listen().unwrap();
+}
+
+#[cfg(feature = "postcopy")]
+fn vhost_user_postcopy_end(path: &Path, barrier: Arc<Barrier>) {
+    let mut frontend = setup_frontend(path, barrier);
+    let _uffd_file = frontend.postcopy_advise().unwrap();
+    frontend.postcopy_listen().unwrap();
+    frontend.postcopy_end().unwrap();
+}
+
+// These tests need an access to the `/dev/userfaultfd`
+// in order to pass.
+#[cfg(feature = "postcopy")]
+#[test]
+fn test_vhost_user_postcopy() {
+    vhost_user_server(vhost_user_postcopy_advise);
+    vhost_user_server(vhost_user_postcopy_listen);
+    vhost_user_server(vhost_user_postcopy_end);
+}

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -24,6 +24,7 @@ vhost-user = []
 vhost-user-frontend = ["vhost-user"]
 vhost-user-backend = ["vhost-user"]
 xen = ["vm-memory/xen"]
+postcopy = []
 
 [dependencies]
 bitflags = "2.4"

--- a/vhost/README.md
+++ b/vhost/README.md
@@ -31,6 +31,12 @@ Frontend is the application that shares its virtqueues, backend is the consumer
 of the virtqueues. Frontend and backend can be either a client (i.e. connecting)
 or server (listening) in the socket communication.
 
+## Postcopy support
+
+To enabled POSTCOPY_* messages support there is a `postcopy` feature.
+Due to how Xen handles memory mappings the `postcopy` feature is not compatible
+with `xen` feature. Enabling both at the same time will result in a compilation error.
+
 ## Xen support
 
 Supporting Xen requires special handling while mapping the guest memory. The

--- a/vhost/src/lib.rs
+++ b/vhost/src/lib.rs
@@ -51,6 +51,12 @@ pub mod vhost_user;
 #[cfg(feature = "vhost-vsock")]
 pub mod vsock;
 
+/// Due to the way `xen` handles memory mappings we can not combine it with
+/// `postcopy` feature which relies on persistent memory mappings. Thus we
+/// disallow enabling both features at the same time.
+#[cfg(all(feature = "postcopy", feature = "xen"))]
+compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
+
 /// Error codes for vhost operations
 #[derive(Debug)]
 pub enum Error {

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -310,4 +310,20 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
             "dummy back end does not support state transfer",
         )))
     }
+
+    #[cfg(feature = "postcopy")]
+    fn postcopy_advice(&mut self) -> Result<File> {
+        let file = tempfile::tempfile().unwrap();
+        Ok(file)
+    }
+
+    #[cfg(feature = "postcopy")]
+    fn postcopy_listen(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "postcopy")]
+    fn postcopy_end(&mut self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -445,6 +445,15 @@ bitflags! {
     }
 }
 
+/// An empty message.
+#[derive(Copy, Clone, Default)]
+pub struct VhostUserEmpty;
+
+// SAFETY: Safe because type is zero size.
+unsafe impl ByteValued for VhostUserEmpty {}
+
+impl VhostUserMsgValidator for VhostUserEmpty {}
+
 /// A generic message to encapsulate a 64-bit value.
 #[repr(transparent)]
 #[derive(Copy, Clone, Default)]


### PR DESCRIPTION
### Summary of the PR

Added ability to use `VHOST_USER_POSTCOPY_ADVISE`, `VHOST_USER_POSTCOPY_LISTEN` and `VHOST_USER_POSTCOPY_END` messages. This includes sending them from the frontend and processing them on the backend.

The `POSTCOPY` messages are only usable when
`VHOST_USER_PROTOCOL_F_PAGEFAULT` feature is negotiated.

Messages and their descriptions are:
- `VHOST_USER_POSTCOPY_ADVISE`:
    When the front-end sends this message to the backend,
    the back-end must open a userfaultfd for later use
    and send it's fd to the front-end.

- `VHOST_USER_POSTCOPY_LISTEN`
    When the back-end receives this message it must ensure
    that shared memory is registered with userfaultfd to
    cause faulting of non-present pages.
    This is always sent sometime after a `VHOST_USER_POSTCOPY_ADVISE`.

- `VHOST_USER_POSTCOPY_END`
    When the back-end receives this message it must disable the
    userfaultfd. The reply is an acknowledgement only.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
