### PR TITLE
Update vmm-sys-util to 0.12.1

### DIFF
--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -18,7 +18,7 @@ vhost = { path = "../vhost", version = "0.9", features = ["vhost-user-backend"] 
 virtio-bindings = "0.2.1"
 virtio-queue = "0.10.0"
 vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 nix = { version = "0.27", features = ["fs"] }

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -29,7 +29,7 @@ xen = ["vm-memory/xen"]
 bitflags = "2.4"
 libc = "0.2.39"
 
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.1"
 vm-memory = { version = "0.13.1", features=["backend-mmap"] }
 
 [dev-dependencies]

--- a/vhost/src/vhost_kern/vdpa.rs
+++ b/vhost/src/vhost_kern/vdpa.rs
@@ -121,7 +121,10 @@ impl<AS: GuestAddressSpace> VhostVdpa for VhostKernVdpa<AS> {
         let mut config = VhostVdpaConfig::new(buffer.len())
             .map_err(|_| Error::IoctlError(IOError::from_raw_os_error(libc::ENOMEM)))?;
 
-        config.as_mut_fam_struct().off = offset;
+        // SAFETY: We are not modifying the `len` field of the vhost-vdpa fam-struct
+        unsafe {
+            config.as_mut_fam_struct().off = offset;
+        }
 
         // SAFETY: This ioctl is called on a valid vhost-vdpa fd and has its
         // return value checked.
@@ -142,7 +145,10 @@ impl<AS: GuestAddressSpace> VhostVdpa for VhostKernVdpa<AS> {
         let mut config = VhostVdpaConfig::new(buffer.len())
             .map_err(|_| Error::IoctlError(IOError::from_raw_os_error(libc::ENOMEM)))?;
 
-        config.as_mut_fam_struct().off = offset;
+        // SAFETY: We are not modifying the `len` field of the vhost-vdpa fam-struct
+        unsafe {
+            config.as_mut_fam_struct().off = offset;
+        }
         config.as_mut_slice().copy_from_slice(buffer);
 
         let ret =


### PR DESCRIPTION
Hey everyone, I am propagating some dependency updates across the rust-vmm ecosystem. This one brings a fix for a security vulnerability behind feature-gated code not used by vhost (the with-serde feature), see [GHSA-875g-mfp6-g7f9](https://github.com/rust-vmm/vmm-sys-util/security/advisories/GHSA-875g-mfp6-g7f9).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
