### PR TITLE
chore: Prepare vhost 0.10.0 and vhost-user-backend 0.12.0 releases

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -9,6 +9,19 @@
 
 ### Deprecated
 
+## v0.12.0
+
+### Fixed
+- [[#210](https://github.com/rust-vmm/vhost/pull/210)] Enable all vrings upon receipt of `VHOST_USER_SET_FEATURES`
+  message.
+- [[#212](https://github.com/rust-vmm/vhost/pull/212)] Validate queue index in `VhostUserHandler::set_vring_base`
+  to avoid potential out-of-bounds panic.
+
+### Changed
+- [[#214](https://github.com/rust-vmm/vhost/pull/214)] Avoid indexing the same Vec multiple times by locally caching the
+  result of `Vec:get`.
+- [[#219]](https://github.com/rust-vmm/vhost/pull/219) Update vmm-sys-util dependency to 0.12.1 and vm-memory dependency to 0.14.0.
+
 ## v0.11.0
 
 ### Added

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -17,11 +17,11 @@ log = "0.4.17"
 vhost = { path = "../vhost", version = "0.9", features = ["vhost-user-backend"] }
 virtio-bindings = "0.2.1"
 virtio-queue = "0.10.0"
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 nix = { version = "0.27", features = ["fs"] }
 vhost = { path = "../vhost", version = "0.9", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -14,7 +14,7 @@ xen = ["vm-memory/xen", "vhost/xen"]
 [dependencies]
 libc = "0.2.39"
 log = "0.4.17"
-vhost = { path = "../vhost", version = "0.9", features = ["vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.10", features = ["vhost-user-backend"] }
 virtio-bindings = "0.2.1"
 virtio-queue = "0.11.0"
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
@@ -22,6 +22,6 @@ vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 nix = { version = "0.27", features = ["fs"] }
-vhost = { path = "../vhost", version = "0.9", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.10", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.39"
 log = "0.4.17"
 vhost = { path = "../vhost", version = "0.9", features = ["vhost-user-backend"] }
 virtio-bindings = "0.2.1"
-virtio-queue = "0.10.0"
+virtio-queue = "0.11.0"
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = "0.12.1"
 

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -9,6 +9,18 @@
 
 ### Deprecated
 
+## [0.10.0]
+
+### Changed
+- [[#219]](https://github.com/rust-vmm/vhost/pull/219) Update vmm-sys-util dependency to 0.12.1.
+
+### Remove
+- [[#202](https://github.com/rust-vmm/vhost/pull/202)] Do not expose for internal-usage-only `NOOP` and `MAX_CMD` requests.
+- [[#205](https://github.com/rust-vmm/vhost/pull/205)] Remove some commented out code.
+
+### Fixed
+- [[#208](https://github.com/rust-vmm/vhost/pull/208)] Fix various message structs being `repr(Rust)` instead of `repr(C)`.
+
 ## [0.9.0]
 
 ### Changed

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.9.0"
+version = "0.10.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -30,7 +30,7 @@ bitflags = "2.4"
 libc = "0.2.39"
 
 vmm-sys-util = "0.12.1"
-vm-memory = { version = "0.13.1", features=["backend-mmap"] }
+vm-memory = { version = "0.14.0", features=["backend-mmap"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -476,7 +476,7 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
     /// * - InvalidMessage: received a invalid message.
-    pub fn recv_body<T: ByteValued + Sized + VhostUserMsgValidator>(
+    pub fn recv_body<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
     ) -> Result<(VhostUserMsgHeader<R>, T, Option<Vec<File>>)> {
         let mut hdr = VhostUserMsgHeader::default();
@@ -558,7 +558,7 @@ impl<R: Req> Endpoint<R> {
     /// * - PartialMessage: received a partial message.
     /// * - InvalidMessage: received a invalid message.
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
-    pub fn recv_payload_into_buf<T: ByteValued + Sized + VhostUserMsgValidator>(
+    pub fn recv_payload_into_buf<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
         buf: &mut [u8],
     ) -> Result<(VhostUserMsgHeader<R>, T, usize, Option<Vec<File>>)> {

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -641,7 +641,7 @@ impl FrontendInternal {
         Ok(hdr)
     }
 
-    fn recv_reply<T: ByteValued + Sized + VhostUserMsgValidator>(
+    fn recv_reply<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
         hdr: &VhostUserMsgHeader<FrontendReq>,
     ) -> VhostUserResult<T> {
@@ -657,7 +657,7 @@ impl FrontendInternal {
         Ok(body)
     }
 
-    fn recv_reply_with_files<T: ByteValued + Sized + VhostUserMsgValidator>(
+    fn recv_reply_with_files<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
         hdr: &VhostUserMsgHeader<FrontendReq>,
     ) -> VhostUserResult<(T, Option<Vec<File>>)> {
@@ -673,7 +673,7 @@ impl FrontendInternal {
         Ok((body, files))
     }
 
-    fn recv_reply_with_payload<T: ByteValued + Sized + VhostUserMsgValidator>(
+    fn recv_reply_with_payload<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
         hdr: &VhostUserMsgHeader<FrontendReq>,
     ) -> VhostUserResult<(T, Vec<u8>, Option<Vec<File>>)> {


### PR DESCRIPTION
This release only includes a dependency update, which is visible in the public API through `VhostBackend::set_vring_kick` and `VhostBackend::set_vring_call`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
