### PR TITLE
vhost-user-backend: bump up MAX_MEM_SLOTS to 509

### DIFF
--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -30,7 +30,10 @@ use super::event_loop::{VringEpollError, VringEpollResult};
 use super::vring::VringT;
 use super::GM;
 
-const MAX_MEM_SLOTS: u64 = 32;
+// vhost in the kernel usually supports 509 mem slots.
+// The 509 used to be the KVM limit, it supported 512, but 3 were used
+// for internal purposes (nowadays, it supports more than that).
+const MAX_MEM_SLOTS: u64 = 509;
 
 #[derive(Debug)]
 /// Errors related to vhost-user handler.

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -211,7 +211,7 @@ fn vhost_user_client(path: &Path, barrier: Arc<Barrier>) {
     let state = frontend.get_vring_base(0).unwrap();
     frontend.set_vring_base(0, state as u16).unwrap();
 
-    assert_eq!(frontend.get_max_mem_slots().unwrap(), 32);
+    assert_eq!(frontend.get_max_mem_slots().unwrap(), 509);
     let region = VhostUserMemoryRegionInfo::new(0x800000, 0x100000, addr, 0, fd.file().as_raw_fd());
     frontend.add_mem_region(&region).unwrap();
     frontend.remove_mem_region(&region).unwrap();

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -8,7 +8,7 @@ use super::*;
 
 pub const MAX_QUEUE_NUM: usize = 2;
 pub const MAX_VRING_NUM: usize = 256;
-pub const MAX_MEM_SLOTS: usize = 32;
+pub const MAX_MEM_SLOTS: usize = 509;
 pub const VIRTIO_FEATURES: u64 = 0x40000003;
 
 #[derive(Default)]

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -490,7 +490,7 @@ mod tests {
         frontend.set_vring_err(0, &eventfd).unwrap();
 
         let max_mem_slots = frontend.get_max_mem_slots().unwrap();
-        assert_eq!(max_mem_slots, 32);
+        assert_eq!(max_mem_slots, 509);
 
         let region_file: File = TempFile::new().unwrap().into_file();
         let region =


### PR DESCRIPTION
### Summary of the PR

Let's support up to 509 memslots, just like vhost in the kernel usually does. This is required to properly support memory hotplug, either using multyiple DIMMs (ACPI supports up to 256) or using virtio-mem.

The 509 used to be the KVM limit, it supported 512, but 3 were used for internal purposes. Currently, KVM supports more than 512, but it usually doesn't make use of more than ~260 (i.e., 256 DIMMs + boot memory), except when other memory devices like PCI devices with BARs are used. So, 509 seems to work well for vhost in the kernel.

Details can be found in the QEMU change that made virtio-mem consume up to 256 memslots accross all virtio-mem devices. [1]

509 memslots implies 509 VMAs/mappings in the worst case (even though, in practice with virtio-mem we won't be seeing more than ~260 in most setups).

With max_map_count under Linux defaulting to 64k, 509 memslots still correspond to less than 1% of the maxium number of mappings. There are plenty left for the application to consume.

[1] https://lore.kernel.org/all/20230926185738.277351-1-david@redhat.com/

