### PR TITLE
vhost-user-backend: Fix SET_VRING_KICK should not disable the vring

### DIFF
--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -257,7 +257,7 @@ where
         // changing some configuration aspects on the fly.
         // (see https://qemu-project.gitlab.io/qemu/interop/vhost-user.html#ring-states)
         //
-        // Note: If `VHOST_USER_F_PROTOCOL_FEATURES` has not been negotiated we must leave
+        // Note: If `VHOST_USER_F_PROTOCOL_FEATURES` has been negotiated we must leave
         // the vrings in their current state.
         if self.acked_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() == 0 {
             for vring in self.vrings.iter_mut() {

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -203,7 +203,6 @@ where
             }
         }
 
-        vring.set_enabled(false);
         vring.set_queue_ready(true);
 
         Ok(())


### PR DESCRIPTION
### Summary of the PR

This was introduced in 7f326dd314fdea0f98a19fa039c630b50deaec0b, but
doesn't work with qemu versions < 7.2. SET_FEATURES is received before 
SET_VRING_KICK, we will enable the vrings in set_features() and disabled
them later in set_vring_kick().

Currently, the libvhostuser in qemu disables the vring upon receiving
RESET_OWNER, but that message is currently deprecated. There is not a 
sane place to disable the vring, since according to the spec we can only
do that upon receiving RESET_OWNER (deprecated), RESET_DEVICE (currently
not supported in this crate), and SET_VRING_ENABLE.

The current state of the vhost-user spec is a mess, we need a more
formal spec that just a wall of english.

It also, fixes an incorrect comment.
