### PR TITLE
vhost-user-backend: prepare v0.13.1 release

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### Deprecated
 
+## v0.13.1
+
+### Fixed
+
+- [[#227]](https://github.com/rust-vmm/vhost/pull/227) vhost-user-backend: Fix SET_VRING_KICK should not disable the vring
+
 ## v0.13.0
 
 ### Changed

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"


### PR DESCRIPTION
### Summary of the PR

Fix a regression introduced by commit 7f326dd ("vhost-user-backend: SET_FEATURES must not disable any ring").

SemVer compatibility checked:
```
$ cargo semver-checks check-release -p vhost-user-backend
     Parsing vhost-user-backend v0.13.1 (current)
     Parsing vhost-user-backend v0.13.0 (baseline, cached)
    Checking vhost-user-backend v0.13.0 -> v0.13.1 (minor change)
   Completed [   0.030s] 42 checks; 42 passed, 6 unnecessary
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
