### PR TITLE
tests: add rust-vmm-ci-tests.json pipeline

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,10 @@
+# buildkite custom pipelines
+
+This folder contains the custom pipelines for this repository.
+
+If we add a new pipeline we need to enable it in
+https://buildkite.com/rust-vmm/vhost-ci/steps
+
+Custom pipelines currently defined are:
+- `custom-tests.json`
+  Custom tests to enable only certain features.

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -8,3 +8,11 @@ https://buildkite.com/rust-vmm/vhost-ci/steps
 Custom pipelines currently defined are:
 - `custom-tests.json`
   Custom tests to enable only certain features.
+
+- `rust-vmm-ci-tests.json`
+  This is based on `rust-vmm-ci/.buildkite/test_description.json`.
+  We can't run rust-vmm-ci tests because they enable all the features with
+  `--all-features` and our crates have features that may not be compatible with
+  others (e.g. `xen`). Waiting to solve this problem in rust-vmm-ci (see
+  https://github.com/rust-vmm/rust-vmm-ci/issues/152), we use a custom
+  pipeline based on that but that does not use `--all-features`.

--- a/.buildkite/rust-vmm-ci-tests.json
+++ b/.buildkite/rust-vmm-ci-tests.json
@@ -1,0 +1,112 @@
+{
+  "tests": [
+    {
+      "test_name": "build-gnu",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --release",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "build-musl",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-linux-musl",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "style",
+      "command": "cargo fmt --all -- --check --config format_code_in_doc_comments=true"
+    },
+    {
+      "test_name": "unittests-gnu-all-with-xen",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "unittests-gnu-all-without-xen",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "unittests-musl-all-with-xen",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "unittests-musl-all-without-xen",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "clippy-all-with-xen",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "clippy-all-without-xen",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "check-warnings-all-with-xen",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "check-warnings-all-without-xen",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "coverage",
+      "command": "pytest $(find . -type f -name \"test_coverage.py\")",
+      "docker_plugin": {
+        "privileged": true
+      },
+      "platform": [
+        "x86_64"
+      ]
+    },
+    {
+      "test_name": "commit-format",
+      "command": "pytest $(find . -type f -name \"test_commit_format.py\")",
+      "docker_plugin": {
+        "propagate-environment": true
+      }
+    },
+    {
+      "test_name": "cargo-audit",
+      "command": "[ -e Cargo.lock ] || cargo generate-lockfile; cargo audit -q --deny warnings",
+      "platform": [
+        "x86_64"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Summary of the PR

This is based on `rust-vmm-ci/.buildkite/test_description.json`.
We can't run rust-vmm-ci tests because they enable all the features with
`--all-features` and our crates have features that may not be compatible with
others (e.g. `xen`). Waiting to solve this problem in rust-vmm-ci (see
https://github.com/rust-vmm/rust-vmm-ci/issues/152), we use a custom
pipeline based on that but that does not use `--all-features`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
