### PR TITLE
Release vhost-v0.11.0 and vhost-user-backend-v0.14.0

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -2,13 +2,19 @@
 ## [Unreleased]
 
 ### Added
-[#206](https://github.com/rust-vmm/vhost/pull/206) Add bitmap support for tracking dirty pages during migration
 
 ### Changed
 
 ### Fixed
 
 ### Deprecated
+
+## v0.14.0
+
+### Added
+- [[#203]](https://github.com/rust-vmm/vhost/pull/203) Add back-end's internal state migration support
+- [[#218]](https://github.com/rust-vmm/vhost/pull/218) Adding POSTCOPY support
+- [[#206]](https://github.com/rust-vmm/vhost/pull/206) Add bitmap support for tracking dirty pages during migration
 
 ## v0.13.1
 

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -16,7 +16,7 @@ postcopy = ["vhost/postcopy", "userfaultfd"]
 libc = "0.2.39"
 log = "0.4.17"
 userfaultfd = { version = "0.8.1", optional = true }
-vhost = { path = "../vhost", version = "0.10", features = ["vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.11", features = ["vhost-user-backend"] }
 virtio-bindings = "0.2.1"
 virtio-queue = "0.11.0"
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
@@ -24,6 +24,6 @@ vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 nix = { version = "0.28", features = ["fs"] }
-vhost = { path = "../vhost", version = "0.10", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.11", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 tempfile = "3.2.0"

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -2,13 +2,19 @@
 ## [Unreleased]
 
 ### Added
-[#206](https://github.com/rust-vmm/vhost/pull/206) Add bitmap support for tracking dirty pages during migration
 
 ### Changed
 
 ### Fixed
 
 ### Deprecated
+
+## [0.11.0]
+
+### Added
+- [[#203]](https://github.com/rust-vmm/vhost/pull/203) Add back-end's internal state migration support
+- [[#218]](https://github.com/rust-vmm/vhost/pull/218) Adding POSTCOPY support
+- [[#206]](https://github.com/rust-vmm/vhost/pull/206) Add bitmap support for tracking dirty pages during migration
 
 ## [0.10.0]
 

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.10.0"
+version = "0.11.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
### Summary of the PR

This release adds support for live migration, adding dirty pages tracking and initial postcopy support.

Closes #234 