### PR TITLE
Add support for VHOST_USER_GPU_SET_SOCKET

### DIFF
--- a/.buildkite/rust-vmm-ci-tests.json
+++ b/.buildkite/rust-vmm-ci-tests.json
@@ -22,7 +22,7 @@
     },
     {
       "test_name": "unittests-gnu-all-with-xen",
-      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen",
       "platform": [
         "x86_64",
         "aarch64"
@@ -30,7 +30,7 @@
     },
     {
       "test_name": "unittests-gnu-all-without-xen",
-      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"
@@ -38,7 +38,7 @@
     },
     {
       "test_name": "unittests-musl-all-with-xen",
-      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen",
       "platform": [
         "x86_64",
         "aarch64"
@@ -46,7 +46,7 @@
     },
     {
       "test_name": "unittests-musl-all-without-xen",
-      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"
@@ -54,7 +54,7 @@
     },
     {
       "test_name": "clippy-all-with-xen",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
         "aarch64"
@@ -62,7 +62,7 @@
     },
     {
       "test_name": "clippy-all-without-xen",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
         "aarch64"
@@ -70,7 +70,7 @@
     },
     {
       "test_name": "check-warnings-all-with-xen",
-      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen",
       "platform": [
         "x86_64",
         "aarch64"
@@ -78,7 +78,7 @@
     },
     {
       "test_name": "check-warnings-all-without-xen",
-      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"

--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 - [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support
+- [[#239]](https://github.com/rust-vmm/vhost/pull/239) Add support for `VHOST_USER_GPU_SET_SOCKET`
 
 ### Changed
 - [[#240]](https://github.com/rust-vmm/vhost/pull/240) Move the set of event_idx property from set_vring_base callback to set_features one

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 [features]
 xen = ["vm-memory/xen", "vhost/xen"]
 postcopy = ["vhost/postcopy", "userfaultfd"]
+gpu-socket = ["vhost/gpu-socket"]
 
 [dependencies]
 libc = "0.2.39"

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -21,9 +21,12 @@ use vhost::vhost_user::message::{
     VhostUserMemoryRegion, VhostUserProtocolFeatures, VhostUserSingleMemoryRegion,
     VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
 };
+#[cfg(feature = "gpu-socket")]
+use vhost::vhost_user::GpuBackend;
 use vhost::vhost_user::{
     Backend, Error as VhostUserError, Result as VhostUserResult, VhostUserBackendReqHandlerMut,
 };
+
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Error as VirtQueError, QueueT};
 use vm_memory::mmap::NewBitmap;
@@ -550,6 +553,11 @@ where
             backend.set_shared_object_flag(true);
         }
         self.backend.set_backend_req_fd(backend);
+    }
+
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&mut self, gpu_backend: GpuBackend) {
+        self.backend.set_gpu_socket(gpu_backend);
     }
 
     fn get_inflight_fd(

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -10,6 +10,8 @@ use std::thread;
 use vhost::vhost_user::message::{
     VhostUserConfigFlags, VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures,
 };
+#[cfg(feature = "gpu-socket")]
+use vhost::vhost_user::GpuBackend;
 use vhost::vhost_user::{Backend, Frontend, Listener, VhostUserFrontend};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
@@ -76,6 +78,9 @@ impl VhostUserBackendMut for MockVhostBackend {
 
         Ok(())
     }
+
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
 
     fn update_memory(&mut self, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
         let mem = atomic_mem.memory();

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 - [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support
+- [[#239]](https://github.com/rust-vmm/vhost/pull/239) Add support for `VHOST_USER_GPU_SET_SOCKET`
 
 ### Changed
 - [[#243]](https://github.com/rust-vmm/vhost/pull/243) Ignore unknown bits in `VHOST_USER_GET_PROTOCOL_FEATURES` response.

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -23,6 +23,7 @@ vhost-net = ["vhost-kern"]
 vhost-user = []
 vhost-user-frontend = ["vhost-user"]
 vhost-user-backend = ["vhost-user"]
+gpu-socket = ["vhost-user"]
 xen = ["vm-memory/xen"]
 postcopy = []
 

--- a/vhost/src/vhost_user/backend.rs
+++ b/vhost/src/vhost_user/backend.rs
@@ -32,7 +32,7 @@ impl<S: VhostUserBackendReqHandler> BackendListener<S> {
     pub fn accept(&mut self) -> Result<Option<BackendReqHandler<S>>> {
         if let Some(fd) = self.listener.accept()? {
             return Ok(Some(BackendReqHandler::new(
-                Endpoint::<FrontendReq>::from_stream(fd),
+                Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(fd),
                 self.backend.take().unwrap(),
             )));
         }

--- a/vhost/src/vhost_user/backend_req.rs
+++ b/vhost/src/vhost_user/backend_req.rs
@@ -14,7 +14,7 @@ use super::{Error, HandlerResult, Result, VhostUserFrontendReqHandler};
 use vm_memory::ByteValued;
 
 struct BackendInternal {
-    sock: Endpoint<BackendReq>,
+    sock: Endpoint<VhostUserMsgHeader<BackendReq>>,
 
     // Protocol feature VHOST_USER_PROTOCOL_F_REPLY_ACK has been negotiated.
     reply_ack_negotiated: bool,
@@ -86,7 +86,7 @@ pub struct Backend {
 }
 
 impl Backend {
-    fn new(ep: Endpoint<BackendReq>) -> Self {
+    fn new(ep: Endpoint<VhostUserMsgHeader<BackendReq>>) -> Self {
         Backend {
             node: Arc::new(Mutex::new(BackendInternal {
                 sock: ep,
@@ -114,7 +114,9 @@ impl Backend {
 
     /// Create a new instance from a `UnixStream` object.
     pub fn from_stream(sock: UnixStream) -> Self {
-        Self::new(Endpoint::<BackendReq>::from_stream(sock))
+        Self::new(Endpoint::<VhostUserMsgHeader<BackendReq>>::from_stream(
+            sock,
+        ))
     }
 
     /// Set the negotiation state of the `VHOST_USER_PROTOCOL_F_REPLY_ACK` protocol feature.
@@ -218,7 +220,7 @@ mod tests {
     fn test_backend_req_recv_negative() {
         let (p1, p2) = UnixStream::pair().unwrap();
         let backend = Backend::from_stream(p1);
-        let mut frontend = Endpoint::<BackendReq>::from_stream(p2);
+        let mut frontend = Endpoint::<VhostUserMsgHeader<BackendReq>>::from_stream(p2);
 
         let len = mem::size_of::<VhostUserSharedMsg>();
         let mut hdr = VhostUserMsgHeader::new(

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -12,6 +12,8 @@ use vm_memory::ByteValued;
 
 use super::backend_req::Backend;
 use super::connection::Endpoint;
+#[cfg(feature = "gpu-socket")]
+use super::gpu_backend_req::GpuBackend;
 use super::message::*;
 use super::{take_single_file, Error, Result};
 
@@ -65,6 +67,8 @@ pub trait VhostUserBackendReqHandler {
     fn get_config(&self, offset: u32, size: u32, flags: VhostUserConfigFlags) -> Result<Vec<u8>>;
     fn set_config(&self, offset: u32, buf: &[u8], flags: VhostUserConfigFlags) -> Result<()>;
     fn set_backend_req_fd(&self, _backend: Backend) {}
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&self, gpu_backend: GpuBackend);
     fn get_inflight_fd(&self, inflight: &VhostUserInflight) -> Result<(VhostUserInflight, File)>;
     fn set_inflight_fd(&self, inflight: &VhostUserInflight, file: File) -> Result<()>;
     fn get_max_mem_slots(&self) -> Result<u64>;
@@ -124,6 +128,8 @@ pub trait VhostUserBackendReqHandlerMut {
     ) -> Result<Vec<u8>>;
     fn set_config(&mut self, offset: u32, buf: &[u8], flags: VhostUserConfigFlags) -> Result<()>;
     fn set_backend_req_fd(&mut self, _backend: Backend) {}
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend);
     fn get_inflight_fd(
         &mut self,
         inflight: &VhostUserInflight,
@@ -233,6 +239,11 @@ impl<T: VhostUserBackendReqHandlerMut> VhostUserBackendReqHandler for Mutex<T> {
 
     fn set_backend_req_fd(&self, backend: Backend) {
         self.lock().unwrap().set_backend_req_fd(backend)
+    }
+
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&self, gpu_backend: GpuBackend) {
+        self.lock().unwrap().set_gpu_socket(gpu_backend);
     }
 
     fn get_inflight_fd(&self, inflight: &VhostUserInflight) -> Result<(VhostUserInflight, File)> {
@@ -560,6 +571,11 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
                 let res = self.backend.set_inflight_fd(&msg, file);
                 self.send_ack_message(&hdr, res)?;
             }
+            #[cfg(feature = "gpu-socket")]
+            Ok(FrontendReq::GPU_SET_SOCKET) => {
+                let res = self.set_gpu_socket(files);
+                self.send_ack_message(&hdr, res)?;
+            }
             Ok(FrontendReq::GET_MAX_MEM_SLOTS) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS)?;
                 self.check_request_size(&hdr, size, 0)?;
@@ -796,6 +812,18 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
         Ok(())
     }
 
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&mut self, files: Option<Vec<File>>) -> Result<()> {
+        let file = take_single_file(files).ok_or(Error::InvalidMessage)?;
+        // SAFETY: Safe because we have ownership of the files that were
+        // checked when received. We have to trust that they are Unix sockets
+        // since we have no way to check this. If not, it will fail later.
+        let sock = unsafe { UnixStream::from_raw_fd(file.into_raw_fd()) };
+        let gpu_backend = GpuBackend::from_stream(sock);
+        self.backend.set_gpu_socket(gpu_backend);
+        Ok(())
+    }
+
     fn handle_vring_fd_request(
         &mut self,
         buf: &[u8],
@@ -865,7 +893,8 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
                 | FrontendReq::SET_BACKEND_REQ_FD
                 | FrontendReq::SET_INFLIGHT_FD
                 | FrontendReq::ADD_MEM_REG
-                | FrontendReq::SET_DEVICE_STATE_FD,
+                | FrontendReq::SET_DEVICE_STATE_FD
+                | FrontendReq::GPU_SET_SOCKET,
             ) => Ok(()),
             _ if files.is_some() => Err(Error::InvalidMessage),
             _ => Ok(()),

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -226,7 +226,7 @@ impl<H: MsgHeader> Endpoint<H> {
         body: &T,
         fds: Option<&[RawFd]>,
     ) -> Result<()> {
-        if mem::size_of::<T>() > MAX_MSG_SIZE {
+        if mem::size_of::<T>() > H::MAX_MSG_SIZE {
             return Err(Error::OversizedMsg);
         }
         let bytes = self.send_iovec_all(&[hdr.as_slice(), body.as_slice()], fds)?;
@@ -255,10 +255,10 @@ impl<H: MsgHeader> Endpoint<H> {
         fds: Option<&[RawFd]>,
     ) -> Result<()> {
         let len = payload.len();
-        if mem::size_of::<T>() > MAX_MSG_SIZE {
+        if mem::size_of::<T>() > H::MAX_MSG_SIZE {
             return Err(Error::OversizedMsg);
         }
-        if len > MAX_MSG_SIZE - mem::size_of::<T>() {
+        if len > H::MAX_MSG_SIZE - mem::size_of::<T>() {
             return Err(Error::OversizedMsg);
         }
         if let Some(fd_arr) = fds {

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -102,12 +102,12 @@ impl Drop for Listener {
 }
 
 /// Unix domain socket endpoint for vhost-user connection.
-pub(super) struct Endpoint<R: Req> {
+pub(super) struct Endpoint<H: MsgHeader> {
     sock: UnixStream,
-    _r: PhantomData<R>,
+    _h: PhantomData<H>,
 }
 
-impl<R: Req> Endpoint<R> {
+impl<H: MsgHeader> Endpoint<H> {
     /// Create a new stream by connecting to server at `str`.
     ///
     /// # Return:
@@ -122,7 +122,7 @@ impl<R: Req> Endpoint<R> {
     pub fn from_stream(sock: UnixStream) -> Self {
         Endpoint {
             sock,
-            _r: PhantomData,
+            _h: PhantomData,
         }
     }
 
@@ -196,20 +196,16 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketBroken: the underline socket is broken.
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
-    pub fn send_header(
-        &mut self,
-        hdr: &VhostUserMsgHeader<R>,
-        fds: Option<&[RawFd]>,
-    ) -> Result<()> {
+    pub fn send_header(&mut self, hdr: &H, fds: Option<&[RawFd]>) -> Result<()> {
         // SAFETY: Safe because there can't be other mutable referance to hdr.
         let iovs = unsafe {
             [slice::from_raw_parts(
-                hdr as *const VhostUserMsgHeader<R> as *const u8,
-                mem::size_of::<VhostUserMsgHeader<R>>(),
+                hdr as *const H as *const u8,
+                mem::size_of::<H>(),
             )]
         };
         let bytes = self.send_iovec_all(&iovs[..], fds)?;
-        if bytes != mem::size_of::<VhostUserMsgHeader<R>>() {
+        if bytes != mem::size_of::<H>() {
             return Err(Error::PartialMessage);
         }
         Ok(())
@@ -226,7 +222,7 @@ impl<R: Req> Endpoint<R> {
     /// * - PartialMessage: received a partial message.
     pub fn send_message<T: ByteValued>(
         &mut self,
-        hdr: &VhostUserMsgHeader<R>,
+        hdr: &H,
         body: &T,
         fds: Option<&[RawFd]>,
     ) -> Result<()> {
@@ -234,7 +230,7 @@ impl<R: Req> Endpoint<R> {
             return Err(Error::OversizedMsg);
         }
         let bytes = self.send_iovec_all(&[hdr.as_slice(), body.as_slice()], fds)?;
-        if bytes != mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>() {
+        if bytes != mem::size_of::<H>() + mem::size_of::<T>() {
             return Err(Error::PartialMessage);
         }
         Ok(())
@@ -253,7 +249,7 @@ impl<R: Req> Endpoint<R> {
     /// * - IncorrectFds: wrong number of attached fds.
     pub fn send_message_with_payload<T: ByteValued>(
         &mut self,
-        hdr: &VhostUserMsgHeader<R>,
+        hdr: &H,
         body: &T,
         payload: &[u8],
         fds: Option<&[RawFd]>,
@@ -271,7 +267,7 @@ impl<R: Req> Endpoint<R> {
             }
         }
 
-        let total = mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>() + len;
+        let total = mem::size_of::<H>() + mem::size_of::<T>() + len;
         let len = self.send_iovec_all(&[hdr.as_slice(), body.as_slice(), payload], fds)?;
         if len != total {
             return Err(Error::PartialMessage);
@@ -445,18 +441,18 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
     /// * - InvalidMessage: received a invalid message.
-    pub fn recv_header(&mut self) -> Result<(VhostUserMsgHeader<R>, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    pub fn recv_header(&mut self) -> Result<(H, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut iovs = [iovec {
-            iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-            iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+            iov_base: (&mut hdr as *mut H) as *mut c_void,
+            iov_len: mem::size_of::<H>(),
         }];
         // SAFETY: Safe because we own hdr and it's ByteValued.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
         if bytes == 0 {
             return Err(Error::Disconnected);
-        } else if bytes != mem::size_of::<VhostUserMsgHeader<R>>() {
+        } else if bytes != mem::size_of::<H>() {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() {
             return Err(Error::InvalidMessage);
@@ -478,13 +474,13 @@ impl<R: Req> Endpoint<R> {
     /// * - InvalidMessage: received a invalid message.
     pub fn recv_body<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
-    ) -> Result<(VhostUserMsgHeader<R>, T, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    ) -> Result<(H, T, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut body: T = Default::default();
         let mut iovs = [
             iovec {
-                iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-                iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+                iov_base: (&mut hdr as *mut H) as *mut c_void,
+                iov_len: mem::size_of::<H>(),
             },
             iovec {
                 iov_base: (&mut body as *mut T) as *mut c_void,
@@ -494,7 +490,7 @@ impl<R: Req> Endpoint<R> {
         // SAFETY: Safe because we own hdr and body and they're ByteValued.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
-        let total = mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>();
+        let total = mem::size_of::<H>() + mem::size_of::<T>();
         if bytes != total {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() || !body.is_valid() {
@@ -518,15 +514,12 @@ impl<R: Req> Endpoint<R> {
     /// * - SocketError: other socket related errors.
     /// * - PartialMessage: received a partial message.
     /// * - InvalidMessage: received a invalid message.
-    pub fn recv_body_into_buf(
-        &mut self,
-        buf: &mut [u8],
-    ) -> Result<(VhostUserMsgHeader<R>, usize, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    pub fn recv_body_into_buf(&mut self, buf: &mut [u8]) -> Result<(H, usize, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut iovs = [
             iovec {
-                iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-                iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+                iov_base: (&mut hdr as *mut H) as *mut c_void,
+                iov_len: mem::size_of::<H>(),
             },
             iovec {
                 iov_base: buf.as_mut_ptr() as *mut c_void,
@@ -537,13 +530,13 @@ impl<R: Req> Endpoint<R> {
         // and it's safe to fill a byte slice with arbitrary data.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
-        if bytes < mem::size_of::<VhostUserMsgHeader<R>>() {
+        if bytes < mem::size_of::<H>() {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() {
             return Err(Error::InvalidMessage);
         }
 
-        Ok((hdr, bytes - mem::size_of::<VhostUserMsgHeader<R>>(), files))
+        Ok((hdr, bytes - mem::size_of::<H>(), files))
     }
 
     /// Receive a message with optional payload and attached file descriptors.
@@ -561,13 +554,13 @@ impl<R: Req> Endpoint<R> {
     pub fn recv_payload_into_buf<T: ByteValued + Sized + VhostUserMsgValidator + Default>(
         &mut self,
         buf: &mut [u8],
-    ) -> Result<(VhostUserMsgHeader<R>, T, usize, Option<Vec<File>>)> {
-        let mut hdr = VhostUserMsgHeader::default();
+    ) -> Result<(H, T, usize, Option<Vec<File>>)> {
+        let mut hdr = H::default();
         let mut body: T = Default::default();
         let mut iovs = [
             iovec {
-                iov_base: (&mut hdr as *mut VhostUserMsgHeader<R>) as *mut c_void,
-                iov_len: mem::size_of::<VhostUserMsgHeader<R>>(),
+                iov_base: (&mut hdr as *mut H) as *mut c_void,
+                iov_len: mem::size_of::<H>(),
             },
             iovec {
                 iov_base: (&mut body as *mut T) as *mut c_void,
@@ -583,7 +576,7 @@ impl<R: Req> Endpoint<R> {
         // arbitrary data.
         let (bytes, files) = unsafe { self.recv_into_iovec_all(&mut iovs[..])? };
 
-        let total = mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<T>();
+        let total = mem::size_of::<H>() + mem::size_of::<T>();
         if bytes < total {
             return Err(Error::PartialMessage);
         } else if !hdr.is_valid() || !body.is_valid() {
@@ -594,7 +587,7 @@ impl<R: Req> Endpoint<R> {
     }
 }
 
-impl<T: Req> AsRawFd for Endpoint<T> {
+impl<H: MsgHeader> AsRawFd for Endpoint<H> {
     fn as_raw_fd(&self) -> RawFd {
         self.sock.as_raw_fd()
     }
@@ -669,9 +662,9 @@ mod tests {
         let path = temp_path();
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
-        let mut frontend = Endpoint::<FrontendReq>::connect(&path).unwrap();
+        let mut frontend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         let buf1 = [0x1, 0x2, 0x3, 0x4];
         let mut len = frontend.send_slice(&buf1[..], None).unwrap();
@@ -695,9 +688,9 @@ mod tests {
         let path = temp_path();
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
-        let mut frontend = Endpoint::<FrontendReq>::connect(&path).unwrap();
+        let mut frontend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         let mut fd = TempFile::new().unwrap().into_file();
         write!(fd, "test").unwrap();
@@ -846,9 +839,9 @@ mod tests {
         let path = temp_path();
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
-        let mut frontend = Endpoint::<FrontendReq>::connect(&path).unwrap();
+        let mut frontend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         let mut hdr1 =
             VhostUserMsgHeader::new(FrontendReq::GET_FEATURES, 0, mem::size_of::<u64>() as u32);
@@ -883,7 +876,7 @@ mod tests {
         let listener = Listener::new(&path, true).unwrap();
         let mut frontend = UnixStream::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         write!(frontend, "a").unwrap();
         drop(frontend);
@@ -896,7 +889,7 @@ mod tests {
         let listener = Listener::new(&path, true).unwrap();
         let _ = UnixStream::connect(&path).unwrap();
         let sock = listener.accept().unwrap().unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(sock);
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock);
 
         assert!(matches!(backend.recv_header(), Err(Error::Disconnected)));
     }

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -259,6 +259,9 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
         Ok(())
     }
 
+    #[cfg(feature = "gpu-socket")]
+    fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
+
     fn get_inflight_fd(
         &mut self,
         inflight: &VhostUserInflight,

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -106,7 +106,7 @@ pub struct Frontend {
 
 impl Frontend {
     /// Create a new instance.
-    fn new(ep: Endpoint<FrontendReq>, max_queue_num: u64) -> Self {
+    fn new(ep: Endpoint<VhostUserMsgHeader<FrontendReq>>, max_queue_num: u64) -> Self {
         Frontend {
             node: Arc::new(Mutex::new(FrontendInternal {
                 main_sock: ep,
@@ -128,7 +128,10 @@ impl Frontend {
 
     /// Create a new instance from a Unix stream socket.
     pub fn from_stream(sock: UnixStream, max_queue_num: u64) -> Self {
-        Self::new(Endpoint::<FrontendReq>::from_stream(sock), max_queue_num)
+        Self::new(
+            Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(sock),
+            max_queue_num,
+        )
     }
 
     /// Create a new vhost-user frontend endpoint.
@@ -140,7 +143,7 @@ impl Frontend {
     pub fn connect<P: AsRef<Path>>(path: P, max_queue_num: u64) -> Result<Self> {
         let mut retry_count = 5;
         let endpoint = loop {
-            match Endpoint::<FrontendReq>::connect(&path) {
+            match Endpoint::<VhostUserMsgHeader<FrontendReq>>::connect(&path) {
                 Ok(endpoint) => break Ok(endpoint),
                 Err(e) => match &e {
                     VhostUserError::SocketConnect(why) => {
@@ -597,7 +600,7 @@ impl VhostUserMemoryContext {
 
 struct FrontendInternal {
     // Used to send requests to the backend.
-    main_sock: Endpoint<FrontendReq>,
+    main_sock: Endpoint<VhostUserMsgHeader<FrontendReq>>,
     // Cached virtio features from the backend.
     virtio_features: u64,
     // Cached acked virtio features from the driver.
@@ -817,7 +820,9 @@ mod tests {
         ))
     }
 
-    fn create_pair<P: AsRef<Path>>(path: P) -> (Frontend, Endpoint<FrontendReq>) {
+    fn create_pair<P: AsRef<Path>>(
+        path: P,
+    ) -> (Frontend, Endpoint<VhostUserMsgHeader<FrontendReq>>) {
         let listener = Listener::new(&path, true).unwrap();
         listener.set_nonblocking(true).unwrap();
         let frontend = Frontend::connect(path, 2).unwrap();
@@ -832,7 +837,9 @@ mod tests {
         listener.set_nonblocking(true).unwrap();
 
         let frontend = Frontend::connect(&path, 1).unwrap();
-        let mut backend = Endpoint::<FrontendReq>::from_stream(listener.accept().unwrap().unwrap());
+        let mut backend = Endpoint::<VhostUserMsgHeader<FrontendReq>>::from_stream(
+            listener.accept().unwrap().unwrap(),
+        );
 
         assert!(frontend.as_raw_fd() > 0);
         // Send two messages continuously
@@ -1001,7 +1008,7 @@ mod tests {
             .unwrap_err();
     }
 
-    fn create_pair2() -> (Frontend, Endpoint<FrontendReq>) {
+    fn create_pair2() -> (Frontend, Endpoint<VhostUserMsgHeader<FrontendReq>>) {
         let path = temp_path();
         let (frontend, peer) = create_pair(path);
 

--- a/vhost/src/vhost_user/frontend_req_handler.rs
+++ b/vhost/src/vhost_user/frontend_req_handler.rs
@@ -123,7 +123,7 @@ impl<S: VhostUserFrontendReqHandlerMut> VhostUserFrontendReqHandler for Mutex<S>
 /// [VhostUserFrontendReqHandler]: trait.VhostUserFrontendReqHandler.html
 pub struct FrontendReqHandler<S: VhostUserFrontendReqHandler> {
     // underlying Unix domain socket for communication
-    sub_sock: Endpoint<BackendReq>,
+    sub_sock: Endpoint<VhostUserMsgHeader<BackendReq>>,
     tx_sock: UnixStream,
     // Protocol feature VHOST_USER_PROTOCOL_F_REPLY_ACK has been negotiated.
     reply_ack_negotiated: bool,
@@ -146,7 +146,7 @@ impl<S: VhostUserFrontendReqHandler> FrontendReqHandler<S> {
         let (tx, rx) = UnixStream::pair().map_err(Error::SocketError)?;
 
         Ok(FrontendReqHandler {
-            sub_sock: Endpoint::<BackendReq>::from_stream(rx),
+            sub_sock: Endpoint::<VhostUserMsgHeader<BackendReq>>::from_stream(rx),
             tx_sock: tx,
             reply_ack_negotiated: false,
             backend,

--- a/vhost/src/vhost_user/gpu_backend_req.rs
+++ b/vhost/src/vhost_user/gpu_backend_req.rs
@@ -1,15 +1,68 @@
 // Copyright (C) 2024 Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io;
+use std::os::fd::RawFd;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use vm_memory::ByteValued;
+
+use crate::vhost_user;
 use crate::vhost_user::connection::Endpoint;
 use crate::vhost_user::gpu_message::*;
+use crate::vhost_user::message::VhostUserMsgValidator;
+use crate::vhost_user::Error;
 
 struct BackendInternal {
+    sock: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>,
     // whether the endpoint has encountered any failure
     error: Option<i32>,
+}
+
+fn io_err_convert_fn(info: &str) -> impl Fn(vhost_user::Error) -> io::Error + '_ {
+    move |e| io::Error::new(io::ErrorKind::Other, format!("{info}: {e}"))
+}
+
+impl BackendInternal {
+    fn check_state(&self) -> io::Result<u64> {
+        match self.error {
+            Some(e) => Err(io_err_convert_fn("check_state")(Error::SocketBroken(
+                io::Error::from_raw_os_error(e),
+            ))),
+            None => Ok(0),
+        }
+    }
+
+    fn send_header(
+        &mut self,
+        request: GpuBackendReq,
+        fds: Option<&[RawFd]>,
+    ) -> io::Result<VhostUserGpuMsgHeader<GpuBackendReq>> {
+        self.check_state()?;
+        let hdr = VhostUserGpuMsgHeader::new(request, 0, 0);
+        self.sock
+            .send_header(&hdr, fds)
+            .map_err(io_err_convert_fn("send_header"))?;
+        Ok(hdr)
+    }
+
+    // Note that there is no VHOST_USER_PROTOCOL_F_REPLY_ACK for this protocol, some messages always
+    // expect a reply/ack and others don't expect a reply/ack at all.
+    fn recv_reply<V: ByteValued + Sized + Default + VhostUserMsgValidator>(
+        &mut self,
+        hdr: &VhostUserGpuMsgHeader<GpuBackendReq>,
+    ) -> io::Result<V> {
+        self.check_state()?;
+        let (reply, body, rfds) = self
+            .sock
+            .recv_body::<V>()
+            .map_err(io_err_convert_fn("recv_body"))?;
+        if !reply.is_reply_for(hdr) || rfds.is_some() || !body.is_valid() {
+            return Err(io_err_convert_fn("Unexpected reply")(Error::InvalidMessage));
+        }
+        Ok(body)
+    }
 }
 
 /// Proxy for sending messages from the backend to the fronted
@@ -22,14 +75,26 @@ pub struct GpuBackend {
 }
 
 impl GpuBackend {
-    fn new(_ep: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>) -> Self {
+    fn new(ep: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>) -> Self {
         Self {
-            node: Arc::new(Mutex::new(BackendInternal { error: None })),
+            node: Arc::new(Mutex::new(BackendInternal {
+                sock: ep,
+                error: None,
+            })),
         }
     }
 
     fn node(&self) -> MutexGuard<BackendInternal> {
         self.node.lock().unwrap()
+    }
+
+    /// Send the VHOST_USER_GPU_GET_DISPLAY_INFO message to the frontend and wait for a reply.
+    /// Get the preferred display configuration.
+    pub fn get_display_info(&self) -> io::Result<VirtioGpuRespDisplayInfo> {
+        let mut node = self.node();
+
+        let hdr = node.send_header(GpuBackendReq::GET_DISPLAY_INFO, None)?;
+        node.recv_reply(&hdr)
     }
 
     /// Create a new instance from a `UnixStream` object.
@@ -46,6 +111,45 @@ impl GpuBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem::size_of;
+    use std::thread;
+    fn frontend_backend_pair() -> (Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>, GpuBackend) {
+        let (backend, frontend) = UnixStream::pair().unwrap();
+        let backend = GpuBackend::from_stream(backend);
+        let frontend = Endpoint::from_stream(frontend);
+
+        (frontend, backend)
+    }
+
+    fn assert_hdr(
+        hdr: &VhostUserGpuMsgHeader<GpuBackendReq>,
+        expected_req_code: GpuBackendReq,
+        expected_size: usize,
+    ) {
+        let size: u32 = expected_size.try_into().unwrap();
+        assert_eq!(
+            hdr,
+            &VhostUserGpuMsgHeader::new(GpuBackendReq::GET_DISPLAY_INFO, 0, size)
+        );
+    }
+
+    fn reply_with_msg<R>(
+        frontend: &mut Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>,
+        req_hdr: &VhostUserGpuMsgHeader<GpuBackendReq>,
+        reply_body: &R,
+    ) where
+        R: ByteValued,
+    {
+        let response_hdr = VhostUserGpuMsgHeader::new(
+            req_hdr.get_code().unwrap(),
+            VhostUserGpuHeaderFlag::REPLY.bits(),
+            size_of::<R>() as u32,
+        );
+
+        frontend
+            .send_message(&response_hdr, reply_body, None)
+            .unwrap();
+    }
 
     #[test]
     fn test_gpu_backend_req_set_failed() {
@@ -54,5 +158,40 @@ mod tests {
         assert!(backend.node().error.is_none());
         backend.set_failed(libc::EAGAIN);
         assert_eq!(backend.node().error, Some(libc::EAGAIN));
+    }
+
+    #[test]
+    fn test_get_display_info() {
+        let (mut frontend, backend) = frontend_backend_pair();
+
+        let expected_response = {
+            let mut resp = VirtioGpuRespDisplayInfo {
+                hdr: Default::default(),
+                pmodes: Default::default(),
+            };
+            resp.pmodes[0] = VirtioGpuDisplayOne {
+                r: VirtioGpuRect {
+                    x: 0,
+                    y: 0,
+                    width: 640,
+                    height: 480,
+                },
+                enabled: 1,
+                flags: 0,
+            };
+            resp
+        };
+
+        let sender_thread = thread::spawn(move || {
+            let response = backend.get_display_info().unwrap();
+            assert_eq!(response, expected_response);
+        });
+
+        let (hdr, fds) = frontend.recv_header().unwrap();
+        assert!(fds.is_none());
+        assert_hdr(&hdr, GpuBackendReq::GET_DISPLAY_INFO, 0);
+
+        reply_with_msg(&mut frontend, &hdr, &expected_response);
+        sender_thread.join().expect("Failed to send!");
     }
 }

--- a/vhost/src/vhost_user/gpu_backend_req.rs
+++ b/vhost/src/vhost_user/gpu_backend_req.rs
@@ -1,0 +1,58 @@
+// Copyright (C) 2024 Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::vhost_user::connection::Endpoint;
+use crate::vhost_user::gpu_message::*;
+
+struct BackendInternal {
+    // whether the endpoint has encountered any failure
+    error: Option<i32>,
+}
+
+/// Proxy for sending messages from the backend to the fronted
+/// over the socket obtained from VHOST_USER_GPU_SET_SOCKET.
+/// The protocol is documented here: https://www.qemu.org/docs/master/interop/vhost-user-gpu.html
+#[derive(Clone)]
+pub struct GpuBackend {
+    // underlying Unix domain socket for communication
+    node: Arc<Mutex<BackendInternal>>,
+}
+
+impl GpuBackend {
+    fn new(_ep: Endpoint<VhostUserGpuMsgHeader<GpuBackendReq>>) -> Self {
+        Self {
+            node: Arc::new(Mutex::new(BackendInternal { error: None })),
+        }
+    }
+
+    fn node(&self) -> MutexGuard<BackendInternal> {
+        self.node.lock().unwrap()
+    }
+
+    /// Create a new instance from a `UnixStream` object.
+    pub fn from_stream(sock: UnixStream) -> Self {
+        Self::new(Endpoint::<VhostUserGpuMsgHeader<GpuBackendReq>>::from_stream(sock))
+    }
+
+    /// Mark endpoint as failed with specified error code.
+    pub fn set_failed(&self, error: i32) {
+        self.node().error = Some(error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpu_backend_req_set_failed() {
+        let (p1, _p2) = UnixStream::pair().unwrap();
+        let backend = GpuBackend::from_stream(p1);
+        assert!(backend.node().error.is_none());
+        backend.set_failed(libc::EAGAIN);
+        assert_eq!(backend.node().error, Some(libc::EAGAIN));
+    }
+}

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -262,6 +262,27 @@ unsafe impl ByteValued for VhostUserGpuEdidRequest {}
 
 impl VhostUserMsgValidator for VhostUserGpuEdidRequest {}
 
+/// The VhostUserGpuUpdate from the vhost-user-gpu specification.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[repr(C)]
+pub struct VhostUserGpuUpdate {
+    /// The id of the scanout that is being updated
+    pub scanout_id: u32,
+    /// The x coordinate of the region to update
+    pub x: u32,
+    /// The y coordinate of the region to update
+    pub y: u32,
+    /// The width of the region to update
+    pub width: u32,
+    /// The height of the region to update
+    pub height: u32,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuUpdate {}
+
+impl VhostUserMsgValidator for VhostUserGpuUpdate {}
+
 /// The virtio_gpu_resp_edid struct from the virtio specification.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -326,6 +326,40 @@ unsafe impl ByteValued for VhostUserGpuDMABUFScanout {}
 
 impl VhostUserMsgValidator for VhostUserGpuDMABUFScanout {}
 
+/// The VhostUserGpuCursorPos from the vhost-user-gpu specification.
+#[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct VhostUserGpuCursorPos {
+    /// The scanout where the cursor is located
+    pub scanout_id: u32,
+    /// The cursor position field x
+    pub x: u32,
+    /// The cursor position field y
+    pub y: u32,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuCursorPos {}
+
+impl VhostUserMsgValidator for VhostUserGpuCursorPos {}
+
+/// The VhostUserGpuCursorUpdate from the vhost-user-gpu specification.
+#[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct VhostUserGpuCursorUpdate {
+    /// The cursor location
+    pub pos: VhostUserGpuCursorPos,
+    /// The cursor hot location x
+    pub hot_x: u32,
+    /// The cursor hot location y
+    pub hot_y: u32,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuCursorUpdate {}
+
+impl VhostUserMsgValidator for VhostUserGpuCursorUpdate {}
+
 /// The virtio_gpu_resp_edid struct from the virtio specification.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -283,6 +283,37 @@ unsafe impl ByteValued for VhostUserGpuUpdate {}
 
 impl VhostUserMsgValidator for VhostUserGpuUpdate {}
 
+/// The VhostUserGpuDMABUFScanout from the vhost-user-gpu specification.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[repr(C)]
+pub struct VhostUserGpuDMABUFScanout {
+    /// The id of the scanout to update
+    pub scanout_id: u32,
+    /// The position field x of the scanout within the DMABUF
+    pub x: u32,
+    /// The position field y of the scanout within the DMABUF
+    pub y: u32,
+    /// Scanout width size
+    pub width: u32,
+    /// Scanout height size
+    pub height: u32,
+    /// The DMABUF width
+    pub fd_width: u32,
+    /// The DMABUF height
+    pub fd_height: u32,
+    /// The DMABUF stride
+    pub fd_stride: u32,
+    /// The DMABUF flags
+    pub fd_flags: u32,
+    /// The DMABUF fourcc
+    pub fd_drm_fourcc: u32,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuDMABUFScanout {}
+
+impl VhostUserMsgValidator for VhostUserGpuDMABUFScanout {}
+
 /// The virtio_gpu_resp_edid struct from the virtio specification.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -326,6 +326,21 @@ unsafe impl ByteValued for VhostUserGpuDMABUFScanout {}
 
 impl VhostUserMsgValidator for VhostUserGpuDMABUFScanout {}
 
+/// The VhostUserGpuDMABUFScanout2 from the vhost-user-gpu specification.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[repr(C, packed)]
+pub struct VhostUserGpuDMABUFScanout2 {
+    /// The dmabuf scanout parameters
+    pub dmabuf_scanout: VhostUserGpuDMABUFScanout,
+    /// The DMABUF modifiers
+    pub modifier: u64,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuDMABUFScanout2 {}
+
+impl VhostUserMsgValidator for VhostUserGpuDMABUFScanout2 {}
+
 /// The VhostUserGpuCursorPos from the vhost-user-gpu specification.
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(C)]

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -1,0 +1,171 @@
+// Copyright (C) 2024 Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementation parts of the protocol on the socket from VHOST_USER_SET_GPU_SOCKET
+//! see: https://www.qemu.org/docs/master/interop/vhost-user-gpu.html
+
+use super::enum_value;
+use crate::vhost_user::message::{MsgHeader, Req, VhostUserMsgValidator};
+use crate::vhost_user::Error;
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use vm_memory::ByteValued;
+
+enum_value! {
+    /// Type of requests sending from gpu backends to gpu frontends.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+    pub enum GpuBackendReq: u32 {
+        /// Get the supported protocol features bitmask.
+        GET_PROTOCOL_FEATURES = 1,
+        /// Enable protocol features using a bitmask.
+        SET_PROTOCOL_FEATURES = 2,
+        /// Get the preferred display configuration.
+        GET_DISPLAY_INFO = 3,
+        /// Set/show the cursor position.
+        CURSOR_POS = 4,
+        /// Set/hide the cursor.
+        CURSOR_POS_HIDE = 5,
+        /// Update the cursor shape and location.
+        CURSOR_UPDATE = 6,
+        /// Set the scanout resolution.
+        /// To disable a scanout, the dimensions width/height are set to 0.
+        SCANOUT = 7,
+        /// Update the scanout content. The data payload contains the graphical bits.
+        /// The display should be flushed and presented.
+        UPDATE = 8,
+        /// Set the scanout resolution/configuration, and share a DMABUF file descriptor for the
+        /// scanout content, which is passed as ancillary data.
+        /// To disable a scanout, the dimensions width/height are set to 0, there is no file
+        /// descriptor passed.
+        DMABUF_SCANOUT = 9,
+        /// The display should be flushed and presented according to updated region from
+        /// VhostUserGpuUpdate.
+        /// Note: there is no data payload, since the scanout is shared thanks to DMABUF,
+        /// that must have been set previously with VHOST_USER_GPU_DMABUF_SCANOUT.
+        DMABUF_UPDATE = 10,
+        /// Retrieve the EDID data for a given scanout.
+        /// This message requires the VHOST_USER_GPU_PROTOCOL_F_EDID protocol feature to be
+        /// supported.
+        GET_EDID = 11,
+        /// Same as DMABUF_SCANOUT, but also sends the dmabuf modifiers appended to the message,
+        /// which were not provided in the other message.
+        /// This message requires the VHOST_USER_GPU_PROTOCOL_F_DMABUF2 protocol feature to be
+        /// supported.
+        DMABUF_SCANOUT2 = 12,
+    }
+}
+
+impl Req for GpuBackendReq {}
+
+// Bit mask for common message flags.
+bitflags! {
+    /// Common message flags for vhost-user requests and replies.
+    pub struct VhostUserGpuHeaderFlag: u32 {
+        /// Mark message as reply.
+        const REPLY = 0x4;
+    }
+}
+
+/// A vhost-user message consists of 3 header fields and an optional payload. All numbers are in the
+/// machine native byte order.
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub(super) struct VhostUserGpuMsgHeader<R: Req> {
+    request: u32,
+    flags: u32,
+    size: u32,
+    _r: PhantomData<R>,
+}
+
+impl<R: Req> Debug for VhostUserGpuMsgHeader<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VhostUserMsgHeader")
+            .field("request", &{ self.request })
+            .field("flags", &{ self.flags })
+            .field("size", &{ self.size })
+            .finish()
+    }
+}
+
+impl<R: Req> PartialEq for VhostUserGpuMsgHeader<R> {
+    fn eq(&self, other: &Self) -> bool {
+        self.request == other.request && self.flags == other.flags && self.size == other.size
+    }
+}
+
+#[allow(dead_code)]
+impl<R: Req> VhostUserGpuMsgHeader<R> {
+    /// Create a new instance of `VhostUserMsgHeader`.
+    pub fn new(request: R, flags: u32, size: u32) -> Self {
+        VhostUserGpuMsgHeader {
+            request: request.into(),
+            flags,
+            size,
+            _r: PhantomData,
+        }
+    }
+
+    /// Get message type.
+    pub fn get_code(&self) -> crate::vhost_user::Result<R> {
+        R::try_from(self.request).map_err(|_| Error::InvalidMessage)
+    }
+
+    /// Check whether it's a reply message.
+    pub fn is_reply(&self) -> bool {
+        (self.flags & VhostUserGpuHeaderFlag::REPLY.bits()) != 0
+    }
+
+    /// Mark message as reply.
+    pub fn set_reply(&mut self, is_reply: bool) {
+        if is_reply {
+            self.flags |= VhostUserGpuHeaderFlag::REPLY.bits();
+        } else {
+            self.flags &= !VhostUserGpuHeaderFlag::REPLY.bits();
+        }
+    }
+
+    /// Check whether it's the reply message for the request `req`.
+    pub fn is_reply_for(&self, req: &VhostUserGpuMsgHeader<R>) -> bool {
+        if let (Ok(code1), Ok(code2)) = (self.get_code(), req.get_code()) {
+            self.is_reply() && !req.is_reply() && code1 == code2
+        } else {
+            false
+        }
+    }
+
+    /// Get message size.
+    pub fn get_size(&self) -> u32 {
+        self.size
+    }
+
+    /// Set message size.
+    pub fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
+impl<R: Req> Default for VhostUserGpuMsgHeader<R> {
+    fn default() -> Self {
+        VhostUserGpuMsgHeader {
+            request: 0,
+            flags: 0,
+            size: 0,
+            _r: PhantomData,
+        }
+    }
+}
+
+// SAFETY: Safe because all fields of VhostUserGpuMsgHeader are POD.
+unsafe impl<R: Req> ByteValued for VhostUserGpuMsgHeader<R> {}
+
+impl<T: Req> VhostUserMsgValidator for VhostUserGpuMsgHeader<T> {
+    fn is_valid(&self) -> bool {
+        self.get_code().is_ok() && VhostUserGpuHeaderFlag::from_bits(self.flags).is_some()
+    }
+}
+
+impl<R: Req> MsgHeader for VhostUserGpuMsgHeader<R> {
+    type Request = R;
+}

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -171,6 +171,18 @@ impl<R: Req> MsgHeader for VhostUserGpuMsgHeader<R> {
     const MAX_MSG_SIZE: usize = u32::MAX as usize;
 }
 
+// Bit mask for vhost-user-gpu protocol feature flags.
+bitflags! {
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    /// Vhost-user-gpu protocol feature flags from the vhost-user-gpu specification.
+    pub struct VhostUserGpuProtocolFeatures: u64 {
+        /// Frontend support for EDID
+        const EDID = 0;
+        /// Frontend support for DMABUF_SCANOUT2
+        const DMABUF2 = 1;
+    }
+}
+
 /// The virtio_gpu_ctrl_hdr from virtio specification
 /// Defined here because some GpuBackend commands return virtio structs, which contain this header.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -291,3 +291,20 @@ impl Default for VirtioGpuRespGetEdid {
 }
 
 impl VhostUserMsgValidator for VirtioGpuRespGetEdid {}
+
+/// The VhostUserGpuScanout from the vhost-user-gpu specification.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[repr(C)]
+pub struct VhostUserGpuScanout {
+    /// The id of the scanout
+    pub scanout_id: u32,
+    /// The scanout width
+    pub width: u32,
+    /// The scanout height
+    pub height: u32,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuScanout {}
+
+impl VhostUserMsgValidator for VhostUserGpuScanout {}

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -248,3 +248,46 @@ pub struct VirtioGpuRespDisplayInfo {
 unsafe impl ByteValued for VirtioGpuRespDisplayInfo {}
 
 impl VhostUserMsgValidator for VirtioGpuRespDisplayInfo {}
+
+/// The VhostUserGpuEdidRequest from the vhost-user-gpu specification.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[repr(C)]
+pub struct VhostUserGpuEdidRequest {
+    /// The id of the scanout to retrieve EDID data for
+    pub scanout_id: u32,
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VhostUserGpuEdidRequest {}
+
+impl VhostUserMsgValidator for VhostUserGpuEdidRequest {}
+
+/// The virtio_gpu_resp_edid struct from the virtio specification.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct VirtioGpuRespGetEdid {
+    /// The fixed header struct
+    pub hdr: VirtioGpuCtrlHdr,
+    /// The actual size of the `edid` field.
+    pub size: u32,
+    /// Padding of the structure
+    pub padding: u32,
+    /// The EDID display data blob (as specified by VESA) for the scanout.
+    pub edid: [u8; 1024],
+}
+
+// SAFETY: Safe because all fields are POD.
+unsafe impl ByteValued for VirtioGpuRespGetEdid {}
+
+impl Default for VirtioGpuRespGetEdid {
+    fn default() -> Self {
+        VirtioGpuRespGetEdid {
+            hdr: VirtioGpuCtrlHdr::default(),
+            size: u32::default(),
+            padding: u32::default(),
+            edid: [0; 1024], // Default value for the edid array (filled with zeros)
+        }
+    }
+}
+
+impl VhostUserMsgValidator for VirtioGpuRespGetEdid {}

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -168,4 +168,5 @@ impl<T: Req> VhostUserMsgValidator for VhostUserGpuMsgHeader<T> {
 
 impl<R: Req> MsgHeader for VhostUserGpuMsgHeader<R> {
     type Request = R;
+    const MAX_MSG_SIZE: usize = u32::MAX as usize;
 }

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -56,6 +56,10 @@ pub(super) trait Req:
 {
 }
 
+pub(super) trait MsgHeader: ByteValued + Copy + Default + VhostUserMsgValidator {
+    type Request: Req;
+}
+
 macro_rules! enum_value {
     (
         $(#[$meta:meta])*
@@ -255,6 +259,10 @@ pub(super) struct VhostUserMsgHeader<R: Req> {
     flags: u32,
     size: u32,
     _r: PhantomData<R>,
+}
+
+impl<R: Req> MsgHeader for VhostUserMsgHeader<R> {
+    type Request = R;
 }
 
 impl<R: Req> Debug for VhostUserMsgHeader<R> {

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -22,7 +22,7 @@ use vm_memory::{mmap::NewBitmap, ByteValued, Error as MmapError, FileOffset, Mma
 #[cfg(feature = "xen")]
 use vm_memory::{GuestAddress, MmapRange, MmapXenFlags};
 
-use super::{Error, Result};
+use super::{enum_value, Error, Result};
 use crate::VringConfigData;
 
 /// The vhost-user specification uses a field of u32 to store message length.
@@ -58,41 +58,6 @@ pub(super) trait Req:
 
 pub(super) trait MsgHeader: ByteValued + Copy + Default + VhostUserMsgValidator {
     type Request: Req;
-}
-
-macro_rules! enum_value {
-    (
-        $(#[$meta:meta])*
-        $vis:vis enum $enum:ident: $T:tt {
-            $(
-                $(#[$variant_meta:meta])*
-                $variant:ident $(= $val:expr)?,
-            )*
-        }
-    ) => {
-        #[repr($T)]
-        $(#[$meta])*
-        $vis enum $enum {
-            $($(#[$variant_meta])* $variant $(= $val)?,)*
-        }
-
-        impl std::convert::TryFrom<$T> for $enum {
-            type Error = ();
-
-            fn try_from(v: $T) -> std::result::Result<Self, Self::Error> {
-                match v {
-                    $(v if v == $enum::$variant as $T => Ok($enum::$variant),)*
-                    _ => Err(()),
-                }
-            }
-        }
-
-        impl std::convert::From<$enum> for $T {
-            fn from(v: $enum) -> $T {
-                v as $T
-            }
-        }
-    }
 }
 
 enum_value! {

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -52,6 +52,8 @@ pub use self::backend_req_handler::{
 mod backend_req;
 #[cfg(feature = "vhost-user-backend")]
 pub use self::backend_req::Backend;
+#[cfg(feature = "gpu-socket")]
+pub mod gpu_message;
 
 /// Errors for vhost-user operations
 #[derive(Debug)]

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -53,7 +53,11 @@ mod backend_req;
 #[cfg(feature = "vhost-user-backend")]
 pub use self::backend_req::Backend;
 #[cfg(feature = "gpu-socket")]
+mod gpu_backend_req;
+#[cfg(feature = "gpu-socket")]
 pub mod gpu_message;
+#[cfg(feature = "gpu-socket")]
+pub use self::gpu_backend_req::GpuBackend;
 
 /// Errors for vhost-user operations
 #[derive(Debug)]


### PR DESCRIPTION
### Summary of the PR
Me and @dorindabassey have been working on this PR, which adds support for the QEMU's [vhost-user-gpu protocol](https://www.qemu.org/docs/master/interop/vhost-user-gpu.html). 
This is a protocol for sending messeges from backend to the fronted, it is needed to implement display output in QEMU to implement a [vhost-user-gpu device](https://github.com/rust-vmm/vhost-device/issues/598).
See issue #236 


This feature is very similar to the `SET_BACKEND_REQ_FD`, so it is implemented in a similar way.
Support is only added for sending these vhost messages from backend to frontend. Support for handling this protocol on frontend is not implemented.

The protocol is very similar to the normal vhost protocol, but the valid header flags of the `VhostUserMsgHeader` and the newly introduced `VhostUserGpuMsgHeader` are different. (There is no version bit, only reply bit is specified). So the `Endpoint` utility was made generic over the header type, not just the request. Unfortunately there is another issue, that the messages `VHOST_USER_GPU_SCANOUT` and `VHOST_USER_GPU_CURSOR_UPDATE` are bigger than the `MAX_MSG_SIZE`. So we added methods for sending bigger messages to `Endpoint`.
https://github.com/rust-vmm/vhost/blob/bd6bf1325b4930d4123f6154ce755bd5289c617b/vhost/src/vhost_user/message.rs#L26-L33


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
