### PR TITLE
vhost-user-backend: set event_idx boolean at set_features

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 ### Changed
+- [[#240]](https://github.com/rust-vmm/vhost/pull/240) Move the set of event_idx property from set_vring_base callback to set_features one
 
 ### Fixed
 

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -279,6 +279,11 @@ where
             }
         }
 
+        let event_idx: bool = (self.acked_features & (1 << VIRTIO_RING_F_EVENT_IDX)) != 0;
+        for vring in self.vrings.iter_mut() {
+            vring.set_queue_event_idx(event_idx);
+        }
+        self.backend.set_event_idx(event_idx);
         self.backend.acked_features(self.acked_features);
 
         Ok(())
@@ -398,11 +403,7 @@ where
             .get(index as usize)
             .ok_or_else(|| VhostUserError::InvalidParam)?;
 
-        let event_idx: bool = (self.acked_features & (1 << VIRTIO_RING_F_EVENT_IDX)) != 0;
-
         vring.set_queue_next_avail(base as u16);
-        vring.set_queue_event_idx(event_idx);
-        self.backend.set_event_idx(event_idx);
 
         Ok(())
     }


### PR DESCRIPTION
A frontend can skip the call to set_vring_base, assuming the ring will be initialized at 0.  If that frontend acknowledge EVENT_IDX vring and VhostUserHandler backend will never know they need to use event idx.

Move the features configuration of the vring and the backend to set_features method.

---
I'm not 100% sure we should remove from set_vring_base.  QEMU history shows SET_FEATURES and SET_VRING_BASE were added by the same patch, so I guess there are no frontends not sending SET_FEATURES.  Even if it is using a transitional device.

At least, it is way more unlikely than frontends skipping SET_VRING_BASE.

Not adding unit/integration test. A guide on how to do that would be useful. Due to that, marking as a draft.