### PR TITLE
Add shared object

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support
 
 ### Changed
 - [[#240]](https://github.com/rust-vmm/vhost/pull/240) Move the set of event_idx property from set_vring_base callback to set_features one

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -546,7 +546,9 @@ where
         if self.acked_protocol_features & VhostUserProtocolFeatures::REPLY_ACK.bits() != 0 {
             backend.set_reply_ack_flag(true);
         }
-
+        if self.acked_protocol_features & VhostUserProtocolFeatures::SHARED_OBJECT.bits() != 0 {
+            backend.set_shared_object_flag(true);
+        }
         self.backend.set_backend_req_fd(backend);
     }
 

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support
 
 ### Changed
 

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -29,6 +29,7 @@ postcopy = []
 [dependencies]
 bitflags = "2.4"
 libc = "0.2.39"
+uuid = { version = "1.8.0", features=["v4", "fast-rng", "macro-diagnostics"] }
 
 vmm-sys-util = "0.12.1"
 vm-memory = { version = "0.14.0", features=["backend-mmap"] }

--- a/vhost/src/vhost_user/backend_req.rs
+++ b/vhost/src/vhost_user/backend_req.rs
@@ -129,6 +129,29 @@ impl Backend {
 }
 
 impl VhostUserFrontendReqHandler for Backend {
+    /// Forward vhost-user shared-object add request to the frontend.
+    fn shared_object_add(&self, uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        self.send_message(BackendReq::SHARED_OBJECT_ADD, uuid, None)
+    }
+
+    /// Forward vhost-user shared-object remove request to the frontend.
+    fn shared_object_remove(&self, uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        self.send_message(BackendReq::SHARED_OBJECT_REMOVE, uuid, None)
+    }
+
+    /// Forward vhost-user shared-object lookup request to the frontend.
+    fn shared_object_lookup(
+        &self,
+        uuid: &VhostUserSharedMsg,
+        fd: &dyn AsRawFd,
+    ) -> HandlerResult<u64> {
+        self.send_message(
+            BackendReq::SHARED_OBJECT_LOOKUP,
+            uuid,
+            Some(&[fd.as_raw_fd()]),
+        )
+    }
+
     /// Forward vhost-user-fs map file requests to the backend.
     fn fs_backend_map(&self, fs: &VhostUserFSBackendMsg, fd: &dyn AsRawFd) -> HandlerResult<u64> {
         self.send_message(BackendReq::FS_MAP, fs, Some(&[fd.as_raw_fd()]))

--- a/vhost/src/vhost_user/frontend_req_handler.rs
+++ b/vhost/src/vhost_user/frontend_req_handler.rs
@@ -544,6 +544,7 @@ mod tests {
             assert_eq!(handler.handle_request().unwrap(), 1);
         });
 
+        backend.set_shared_object_flag(true);
         backend
             .fs_backend_map(&VhostUserFSBackendMsg::default(), &fd)
             .unwrap();
@@ -604,6 +605,7 @@ mod tests {
         });
 
         backend.set_reply_ack_flag(true);
+        backend.set_shared_object_flag(true);
         backend
             .fs_backend_map(&VhostUserFSBackendMsg::default(), &fd)
             .unwrap();

--- a/vhost/src/vhost_user/frontend_req_handler.rs
+++ b/vhost/src/vhost_user/frontend_req_handler.rs
@@ -33,6 +33,25 @@ pub trait VhostUserFrontendReqHandler {
         Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
+    /// Handle shared object add operation
+    fn shared_object_add(&self, _uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Handle shared object remove operation
+    fn shared_object_remove(&self, _uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Handle shared object lookup operation
+    fn shared_object_lookup(
+        &self,
+        _uuid: &VhostUserSharedMsg,
+        _fd: &dyn AsRawFd,
+    ) -> HandlerResult<u64> {
+        Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
     /// Handle virtio-fs map file requests.
     fn fs_backend_map(&self, _fs: &VhostUserFSBackendMsg, _fd: &dyn AsRawFd) -> HandlerResult<u64> {
         Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
@@ -63,6 +82,25 @@ pub trait VhostUserFrontendReqHandler {
 pub trait VhostUserFrontendReqHandlerMut {
     /// Handle device configuration change notifications.
     fn handle_config_change(&mut self) -> HandlerResult<u64> {
+        Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Handle shared object add operation
+    fn shared_object_add(&mut self, _uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Handle shared object remove operation
+    fn shared_object_remove(&mut self, _uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    /// Handle shared object lookup operation
+    fn shared_object_lookup(
+        &mut self,
+        _uuid: &VhostUserSharedMsg,
+        _fd: &dyn AsRawFd,
+    ) -> HandlerResult<u64> {
         Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
@@ -101,6 +139,25 @@ pub trait VhostUserFrontendReqHandlerMut {
 impl<S: VhostUserFrontendReqHandlerMut> VhostUserFrontendReqHandler for Mutex<S> {
     fn handle_config_change(&self) -> HandlerResult<u64> {
         self.lock().unwrap().handle_config_change()
+    }
+
+    /// Handle shared object add operation
+    fn shared_object_add(&self, uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        self.lock().unwrap().shared_object_add(uuid)
+    }
+
+    /// Handle shared object remove operation
+    fn shared_object_remove(&self, uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+        self.lock().unwrap().shared_object_remove(uuid)
+    }
+
+    /// Handle shared object lookup operation
+    fn shared_object_lookup(
+        &self,
+        uuid: &VhostUserSharedMsg,
+        fd: &dyn AsRawFd,
+    ) -> HandlerResult<u64> {
+        self.lock().unwrap().shared_object_lookup(uuid, fd)
     }
 
     fn fs_backend_map(&self, fs: &VhostUserFSBackendMsg, fd: &dyn AsRawFd) -> HandlerResult<u64> {
@@ -230,6 +287,24 @@ impl<S: VhostUserFrontendReqHandler> FrontendReqHandler<S> {
                     .handle_config_change()
                     .map_err(Error::ReqHandlerError)
             }
+            Ok(BackendReq::SHARED_OBJECT_ADD) => {
+                let msg = self.extract_msg_body::<VhostUserSharedMsg>(&hdr, size, &buf)?;
+                self.backend
+                    .shared_object_add(&msg)
+                    .map_err(Error::ReqHandlerError)
+            }
+            Ok(BackendReq::SHARED_OBJECT_REMOVE) => {
+                let msg = self.extract_msg_body::<VhostUserSharedMsg>(&hdr, size, &buf)?;
+                self.backend
+                    .shared_object_remove(&msg)
+                    .map_err(Error::ReqHandlerError)
+            }
+            Ok(BackendReq::SHARED_OBJECT_LOOKUP) => {
+                let msg = self.extract_msg_body::<VhostUserSharedMsg>(&hdr, size, &buf)?;
+                self.backend
+                    .shared_object_lookup(&msg, &files.unwrap()[0])
+                    .map_err(Error::ReqHandlerError)
+            }
             Ok(BackendReq::FS_MAP) => {
                 let msg = self.extract_msg_body::<VhostUserFSBackendMsg>(&hdr, size, &buf)?;
                 // check_attached_files() has validated files
@@ -293,7 +368,7 @@ impl<S: VhostUserFrontendReqHandler> FrontendReqHandler<S> {
         files: &Option<Vec<File>>,
     ) -> Result<()> {
         match hdr.get_code() {
-            Ok(BackendReq::FS_MAP | BackendReq::FS_IO) => {
+            Ok(BackendReq::SHARED_OBJECT_LOOKUP | BackendReq::FS_MAP | BackendReq::FS_IO) => {
                 // Expect a single file is passed.
                 match files {
                     Some(files) if files.len() == 1 => Ok(()),
@@ -370,14 +445,46 @@ impl<S: VhostUserFrontendReqHandler> AsRawFd for FrontendReqHandler<S> {
 mod tests {
     use super::*;
 
+    use std::collections::HashSet;
+
+    use uuid::Uuid;
+
     #[cfg(feature = "vhost-user-backend")]
     use crate::vhost_user::Backend;
     #[cfg(feature = "vhost-user-backend")]
     use std::os::unix::io::FromRawFd;
 
-    struct MockFrontendReqHandler {}
+    struct MockFrontendReqHandler {
+        shared_objects: HashSet<Uuid>,
+    }
+
+    impl MockFrontendReqHandler {
+        fn new() -> Self {
+            Self {
+                shared_objects: HashSet::new(),
+            }
+        }
+    }
 
     impl VhostUserFrontendReqHandlerMut for MockFrontendReqHandler {
+        fn shared_object_add(&mut self, uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+            Ok(!self.shared_objects.insert(uuid.uuid) as u64)
+        }
+
+        fn shared_object_remove(&mut self, uuid: &VhostUserSharedMsg) -> HandlerResult<u64> {
+            Ok(!self.shared_objects.remove(&uuid.uuid) as u64)
+        }
+
+        fn shared_object_lookup(
+            &mut self,
+            uuid: &VhostUserSharedMsg,
+            _fd: &dyn AsRawFd,
+        ) -> HandlerResult<u64> {
+            if self.shared_objects.get(&uuid.uuid).is_some() {
+                return Ok(0);
+            }
+            Ok(1)
+        }
         /// Handle virtio-fs map file requests from the backend.
         fn fs_backend_map(
             &mut self,
@@ -395,7 +502,7 @@ mod tests {
 
     #[test]
     fn test_new_frontend_req_handler() {
-        let backend = Arc::new(Mutex::new(MockFrontendReqHandler {}));
+        let backend = Arc::new(Mutex::new(MockFrontendReqHandler::new()));
         let mut handler = FrontendReqHandler::new(backend).unwrap();
 
         assert!(handler.get_tx_raw_fd() >= 0);
@@ -411,7 +518,7 @@ mod tests {
     #[cfg(feature = "vhost-user-backend")]
     #[test]
     fn test_frontend_backend_req_handler() {
-        let backend = Arc::new(Mutex::new(MockFrontendReqHandler {}));
+        let backend = Arc::new(Mutex::new(MockFrontendReqHandler::new()));
         let mut handler = FrontendReqHandler::new(backend).unwrap();
 
         // SAFETY: Safe because `handler` contains valid fds, and we are
@@ -428,6 +535,13 @@ mod tests {
             let res = handler.handle_request().unwrap();
             assert_eq!(res, 0);
             handler.handle_request().unwrap_err();
+            // Testing shared object messages.
+            assert_eq!(handler.handle_request().unwrap(), 0);
+            assert_eq!(handler.handle_request().unwrap(), 1);
+            assert_eq!(handler.handle_request().unwrap(), 0);
+            assert_eq!(handler.handle_request().unwrap(), 1);
+            assert_eq!(handler.handle_request().unwrap(), 0);
+            assert_eq!(handler.handle_request().unwrap(), 1);
         });
 
         backend
@@ -438,6 +552,23 @@ mod tests {
         backend
             .fs_backend_unmap(&VhostUserFSBackendMsg::default())
             .unwrap();
+
+        let shobj_msg = VhostUserSharedMsg {
+            uuid: Uuid::new_v4(),
+        };
+        assert!(backend.shared_object_add(&shobj_msg).is_ok());
+        assert!(backend.shared_object_add(&shobj_msg).is_ok());
+        assert!(backend.shared_object_lookup(&shobj_msg, &fd).is_ok());
+        assert!(backend
+            .shared_object_lookup(
+                &VhostUserSharedMsg {
+                    uuid: Uuid::new_v4(),
+                },
+                &fd,
+            )
+            .is_ok());
+        assert!(backend.shared_object_remove(&shobj_msg).is_ok());
+        assert!(backend.shared_object_remove(&shobj_msg).is_ok());
         // Ensure that the handler thread did not panic.
         assert!(frontend_handler.join().is_ok());
     }
@@ -445,7 +576,7 @@ mod tests {
     #[cfg(feature = "vhost-user-backend")]
     #[test]
     fn test_frontend_backend_req_handler_with_ack() {
-        let backend = Arc::new(Mutex::new(MockFrontendReqHandler {}));
+        let backend = Arc::new(Mutex::new(MockFrontendReqHandler::new()));
         let mut handler = FrontendReqHandler::new(backend).unwrap();
         handler.set_reply_ack_flag(true);
 
@@ -463,6 +594,13 @@ mod tests {
             let res = handler.handle_request().unwrap();
             assert_eq!(res, 0);
             handler.handle_request().unwrap_err();
+            // Testing shared object messages.
+            assert_eq!(handler.handle_request().unwrap(), 0);
+            assert_eq!(handler.handle_request().unwrap(), 1);
+            assert_eq!(handler.handle_request().unwrap(), 0);
+            assert_eq!(handler.handle_request().unwrap(), 1);
+            assert_eq!(handler.handle_request().unwrap(), 0);
+            assert_eq!(handler.handle_request().unwrap(), 1);
         });
 
         backend.set_reply_ack_flag(true);
@@ -472,6 +610,23 @@ mod tests {
         backend
             .fs_backend_unmap(&VhostUserFSBackendMsg::default())
             .unwrap_err();
+
+        let shobj_msg = VhostUserSharedMsg {
+            uuid: Uuid::new_v4(),
+        };
+        assert!(backend.shared_object_add(&shobj_msg).is_ok());
+        assert!(backend.shared_object_add(&shobj_msg).is_err());
+        assert!(backend.shared_object_lookup(&shobj_msg, &fd).is_ok());
+        assert!(backend
+            .shared_object_lookup(
+                &VhostUserSharedMsg {
+                    uuid: Uuid::new_v4(),
+                },
+                &fd,
+            )
+            .is_err());
+        assert!(backend.shared_object_remove(&shobj_msg).is_ok());
+        assert!(backend.shared_object_remove(&shobj_msg).is_err());
         // Ensure that the handler thread did not panic.
         assert!(frontend_handler.join().is_ok());
     }

--- a/vhost/src/vhost_user/frontend_req_handler.rs
+++ b/vhost/src/vhost_user/frontend_req_handler.rs
@@ -424,7 +424,7 @@ mod tests {
         let stream = unsafe { UnixStream::from_raw_fd(fd) };
         let backend = Backend::from_stream(stream);
 
-        std::thread::spawn(move || {
+        let frontend_handler = std::thread::spawn(move || {
             let res = handler.handle_request().unwrap();
             assert_eq!(res, 0);
             handler.handle_request().unwrap_err();
@@ -438,6 +438,8 @@ mod tests {
         backend
             .fs_backend_unmap(&VhostUserFSBackendMsg::default())
             .unwrap();
+        // Ensure that the handler thread did not panic.
+        assert!(frontend_handler.join().is_ok());
     }
 
     #[cfg(feature = "vhost-user-backend")]
@@ -457,7 +459,7 @@ mod tests {
         let stream = unsafe { UnixStream::from_raw_fd(fd) };
         let backend = Backend::from_stream(stream);
 
-        std::thread::spawn(move || {
+        let frontend_handler = std::thread::spawn(move || {
             let res = handler.handle_request().unwrap();
             assert_eq!(res, 0);
             handler.handle_request().unwrap_err();
@@ -470,5 +472,7 @@ mod tests {
         backend
             .fs_backend_unmap(&VhostUserFSBackendMsg::default())
             .unwrap_err();
+        // Ensure that the handler thread did not panic.
+        assert!(frontend_handler.join().is_ok());
     }
 }

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -203,14 +203,16 @@ enum_value! {
         VRING_CALL = 4,
         /// Indicate that an error occurred on the specific vring.
         VRING_ERR = 5,
+
+        // Non-standard message types.
         /// Virtio-fs draft: map file content into the window.
-        FS_MAP = 6,
+        FS_MAP = 1000,
         /// Virtio-fs draft: unmap file content from the window.
-        FS_UNMAP = 7,
+        FS_UNMAP = 1001,
         /// Virtio-fs draft: sync file content.
-        FS_SYNC = 8,
+        FS_SYNC = 1002,
         /// Virtio-fs draft: perform a read/write from an fd directly to GPA.
-        FS_IO = 9,
+        FS_IO = 1003,
     }
 }
 


### PR DESCRIPTION
### Summary of the PR

Add `SHARED_OBJECT_*` vhost-user message IDs to align with standard at
https://qemu-project.gitlab.io/qemu/interop/vhost-user.html

Move `FS_*` type IDs to avoid current and future collisions.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
