### PR TITLE
vhost_user: ignore unknown features from backend

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support
 
 ### Changed
+- [[#243]](https://github.com/rust-vmm/vhost/pull/243) Ignore unknown bits in `VHOST_USER_GET_PROTOCOL_FEATURES` response.
 
 ### Remove
 - [[#246]](https://github.com/rust-vmm/vhost/pull/246) Remove support for FS_* requests


### PR DESCRIPTION
### Summary of the PR

virtiofsd 1.11.0 added support for VHOST_USER_PROTOCOL_F_DEVICE_STATE. Upgrading virtiofsd meant that the latest released version of Cloud Hypervisor (39.0) was no longer able to communicate with it, because rather than just ignoring the unsupported feature, it got an unrecoverable "invalid message" error.  This demonstrates that it's better for frontends to just ignore offers of unsupported features. If the backend requires some feature, it'll get a chance to know that when we send VHOST_USER_SET_PROTOCOL_FEATURES anyway.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
