### PR TITLE
vhost_user: Remove support for FS_* requests

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 72.12,
+  "coverage_score": 73.04,
   "exclude_path": "vhost/src/vhost_kern/",
   "crate_features": "vhost/vhost-user-frontend,vhost/vhost-user-backend,vhost-user-backend/postcopy"
 }

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Changed
 
+### Remove
+- [[#246]](https://github.com/rust-vmm/vhost/pull/246) Remove support for FS_* requests
+
 ### Fixed
 
 ### Deprecated


### PR DESCRIPTION
### Summary of the PR

Since these non-standard backend request
message types are confirmed not to be used
anymore, let's just remove them.

```
pub enum BackendReq {
    ...
    /// Virtio-fs draft: map file content into the window.
    FS_MAP = 100,
    /// Virtio-fs draft: unmap file content from the window.
    FS_UNMAP = 1001,
    /// Virtio-fs draft: sync file content.
    FS_SYNC = 1002,
    /// Virtio-fs draft: perform a read/write from an fd directly to GPA.
    FS_IO = 1003,
    ...
}
```

Closes: #213

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
