### PR TITLE
Fix bug in unsafe code of test create_listener_from_raw_fd()

### DIFF
--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -617,6 +617,7 @@ fn get_sub_iovs_offset(iov_lens: &[usize], skip_size: usize) -> (usize, usize) {
 mod tests {
     use super::*;
     use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::fd::IntoRawFd;
     use vmm_sys_util::rand::rand_alphanumerics;
     use vmm_sys_util::tempfile::TempFile;
 
@@ -640,8 +641,9 @@ mod tests {
         let path = temp_path();
         let file = File::create(path).unwrap();
 
-        // SAFETY: Safe because `file` contains a valid fd to a file just created.
-        let listener = unsafe { Listener::from_raw_fd(file.as_raw_fd()) };
+        // SAFETY: Safe because `file` contains a valid fd to a file just created and ownership of
+        // the file descriptor is released.
+        let listener = unsafe { Listener::from_raw_fd(file.into_raw_fd()) };
 
         assert!(listener.as_raw_fd() > 0);
     }


### PR DESCRIPTION
### Summary of the PR
This is a small PR to fix a bug in test `create_listener_from_raw_fd()`, to make sure a file descriptor is not closed after ownership is passed to another object.

This actually causes a crash when running `cargo test` using the latest Rust toolchain version `1.80`, with the error message:
```
fatal runtime error: IO Safety violation: owned file descriptor already closed
```
 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.