### PR TITLE
Update comments to accurately reflect queue-to-thread mapping

### DIFF
--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -213,11 +213,12 @@ pub trait VhostUserBackendMut: Send + Sync {
     /// useful for a gpu device.
     fn set_gpu_socket(&mut self, gpu_backend: GpuBackend);
 
-    /// Get the map to map queue index to worker thread index.
+    /// Get the mapping of queue indices to worker thread indices.
     ///
-    /// A return value of [2, 2, 4] means: the first two queues will be handled by worker thread 0,
-    /// the following two queues will be handled by worker thread 1, and the last four queues will
-    /// be handled by worker thread 2.
+    /// A return value of [0b11, 0b1100, 0b11110000] means: 
+    /// - Worker thread 0 handles queues 0 and 1 (0b11).
+    /// - Worker thread 1 handles queues 2 and 3 (0b1100).
+    /// - Worker thread 2 handles queues 4 to 7 (0b11110000).
     fn queues_per_thread(&self) -> Vec<u64> {
         vec![0xffff_ffff]
     }


### PR DESCRIPTION
Pull Request Description
Summary: This PR updates the comments to accurately describe the queue-to-thread mapping functionality using bitmasks.

Details:

The original comment inaccurately described how queue indices map to worker threads.
The updated comment now correctly reflects the logic of queue assignment based on bitmasks.
It provides a clearer and more concise explanation of how each bitmask corresponds to the queues handled by each worker thread.
Example:

The comment now correctly explains that a bitmask configuration of [0b11, 0b1100, 0b11110000] results in:
Worker thread 0 handling queues 0 and 1.
Worker thread 1 handling queues 2 and 3.
Worker thread 2 handling queues 4 to 7.
Why this change is necessary:

The original comment could lead to misunderstandings due to its inconsistency with the implementation.
The updated comment enhances clarity and ensures that the documentation matches the code's behavior.
Testing:

This PR only involves updating comments; no functional code changes were made. Therefore, no additional testing is required.