### PR TITLE
vhost-user-backend: impl Debug for AddrMapping

### DIFF
--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -82,6 +82,7 @@ impl error::Error for VhostUserHandlerError {}
 /// Result of vhost-user handler operations.
 pub type VhostUserHandlerResult<T> = std::result::Result<T, VhostUserHandlerError>;
 
+#[derive(Debug)]
 struct AddrMapping {
     #[cfg(feature = "postcopy")]
     local_addr: u64,


### PR DESCRIPTION
### Summary of the PR

It can be useful to debug the various address mappings sent to a vhost user device backend. impl Debug for both the postcopy and non-postcopy versions of AddrMapping.
