### PR TITLE
Add suport for VHOST_USER_RESET_DEVICE

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#266]](https://github.com/rust-vmm/vhost/pull/266) Add support for `VHOST_USER_RESET_DEVICE`
 
 ### Changed
 

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -58,6 +58,12 @@ pub trait VhostUserBackend: Send + Sync {
     /// Get available vhost protocol features.
     fn protocol_features(&self) -> VhostUserProtocolFeatures;
 
+    /// Reset the emulated device state.
+    ///
+    /// A default implementation is provided as we cannot expect all backends to implement this
+    /// function.
+    fn reset_device(&self) {}
+
     /// Enable or disable the virtio EVENT_IDX feature
     fn set_event_idx(&self, enabled: bool);
 
@@ -179,6 +185,12 @@ pub trait VhostUserBackendMut: Send + Sync {
 
     /// Get available vhost protocol features.
     fn protocol_features(&self) -> VhostUserProtocolFeatures;
+
+    /// Reset the emulated device state.
+    ///
+    /// A default implementation is provided as we cannot expect all backends to implement this
+    /// function.
+    fn reset_device(&mut self) {}
 
     /// Enable or disable the virtio EVENT_IDX feature
     fn set_event_idx(&mut self, enabled: bool);
@@ -305,6 +317,10 @@ impl<T: VhostUserBackend> VhostUserBackend for Arc<T> {
         self.deref().protocol_features()
     }
 
+    fn reset_device(&self) {
+        self.deref().reset_device()
+    }
+
     fn set_event_idx(&self, enabled: bool) {
         self.deref().set_event_idx(enabled)
     }
@@ -384,6 +400,10 @@ impl<T: VhostUserBackendMut> VhostUserBackend for Mutex<T> {
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
         self.lock().unwrap().protocol_features()
+    }
+
+    fn reset_device(&self) {
+        self.lock().unwrap().reset_device()
     }
 
     fn set_event_idx(&self, enabled: bool) {
@@ -468,6 +488,10 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
         self.read().unwrap().protocol_features()
+    }
+
+    fn reset_device(&self) {
+        self.write().unwrap().reset_device()
     }
 
     fn set_event_idx(&self, enabled: bool) {
@@ -589,6 +613,12 @@ pub mod tests {
             VhostUserProtocolFeatures::all()
         }
 
+        fn reset_device(&mut self) {
+            self.event_idx = false;
+            self.events = 0;
+            self.acked_features = 0;
+        }
+
         fn set_event_idx(&mut self, enabled: bool) {
             self.event_idx = enabled;
         }
@@ -668,6 +698,11 @@ pub mod tests {
             GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
         );
         backend.update_memory(mem).unwrap();
+
+        backend.reset_device();
+        assert!(backend.lock().unwrap().events == 0);
+        assert!(!backend.lock().unwrap().event_idx);
+        assert!(backend.lock().unwrap().acked_features == 0);
     }
 
     #[test]
@@ -703,5 +738,10 @@ pub mod tests {
         backend
             .handle_event(0x1, EventSet::IN, &[vring], 0)
             .unwrap();
+
+        backend.reset_device();
+        assert!(backend.read().unwrap().events == 0);
+        assert!(!backend.read().unwrap().event_idx);
+        assert!(backend.read().unwrap().acked_features == 0);
     }
 }

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -256,6 +256,19 @@ where
         Ok(())
     }
 
+    fn reset_device(&mut self) -> VhostUserResult<()> {
+        // Disable all vrings
+        for vring in self.vrings.iter_mut() {
+            vring.set_enabled(false);
+        }
+
+        // Reset device state, retain protocol state
+        self.features_acked = false;
+        self.acked_features = 0;
+        self.backend.reset_device();
+        Ok(())
+    }
+
     fn get_features(&mut self) -> VhostUserResult<u64> {
         Ok(self.backend.features())
     }

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -26,6 +26,8 @@ struct MockVhostBackend {
 }
 
 impl MockVhostBackend {
+    const SUPPORTED_FEATURES: u64 = 0xffff_ffff_ffff_ffff;
+
     fn new() -> Self {
         MockVhostBackend {
             events: 0,
@@ -48,7 +50,7 @@ impl VhostUserBackendMut for MockVhostBackend {
     }
 
     fn features(&self) -> u64 {
-        0xffff_ffff_ffff_ffff
+        Self::SUPPORTED_FEATURES
     }
 
     fn acked_features(&mut self, features: u64) {

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#266]](https://github.com/rust-vmm/vhost/pull/266) Add support for `VHOST_USER_RESET_DEVICE`
 
 ### Changed
 

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -40,6 +40,7 @@ use super::{take_single_file, Error, Result};
 pub trait VhostUserBackendReqHandler {
     fn set_owner(&self) -> Result<()>;
     fn reset_owner(&self) -> Result<()>;
+    fn reset_device(&self) -> Result<()>;
     fn get_features(&self) -> Result<u64>;
     fn set_features(&self, features: u64) -> Result<()>;
     fn set_mem_table(&self, ctx: &[VhostUserMemoryRegion], files: Vec<File>) -> Result<()>;
@@ -95,6 +96,7 @@ pub trait VhostUserBackendReqHandler {
 pub trait VhostUserBackendReqHandlerMut {
     fn set_owner(&mut self) -> Result<()>;
     fn reset_owner(&mut self) -> Result<()>;
+    fn reset_device(&mut self) -> Result<()>;
     fn get_features(&mut self) -> Result<u64>;
     fn set_features(&mut self, features: u64) -> Result<()>;
     fn set_mem_table(&mut self, ctx: &[VhostUserMemoryRegion], files: Vec<File>) -> Result<()>;
@@ -158,6 +160,10 @@ impl<T: VhostUserBackendReqHandlerMut> VhostUserBackendReqHandler for Mutex<T> {
 
     fn reset_owner(&self) -> Result<()> {
         self.lock().unwrap().reset_owner()
+    }
+
+    fn reset_device(&self) -> Result<()> {
+        self.lock().unwrap().reset_device()
     }
 
     fn get_features(&self) -> Result<u64> {
@@ -422,6 +428,12 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
             Ok(FrontendReq::RESET_OWNER) => {
                 self.check_request_size(&hdr, size, 0)?;
                 let res = self.backend.reset_owner();
+                self.send_ack_message(&hdr, res)?;
+            }
+            Ok(FrontendReq::RESET_DEVICE) => {
+                self.check_proto_feature(VhostUserProtocolFeatures::RESET_DEVICE)?;
+                self.check_request_size(&hdr, size, 0)?;
+                let res = self.backend.reset_device();
                 self.send_ack_message(&hdr, res)?;
             }
             Ok(FrontendReq::GET_FEATURES) => {

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -72,6 +72,12 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
         Ok(())
     }
 
+    fn reset_device(&mut self) -> Result<()> {
+        self.features_acked = false;
+        self.acked_features = 0;
+        Ok(())
+    }
+
     fn get_features(&mut self) -> Result<u64> {
         Ok(VIRTIO_FEATURES)
     }


### PR DESCRIPTION
### Summary of the PR

The main point of this PR is to add vhost-user back-end support for the `RESET_DEVICE` message. This message is handled by disabling all vrings and resetting the device state (as per [the specification, look for `VHOST_USER_RESET_DEVICE`](https://qemu-project.gitlab.io/qemu/interop/vhost-user.html#front-end-message-types)). This includes a new `VhostUserBackend::reset_device()` method that back-end implementations may provide to clear additional internal state they keep.

virtiofsd needs this so a hard reset cannot be used to inherit state from a prior user ([virtiofsd issue #167](https://gitlab.com/virtio-fs/virtiofsd/-/issues/167) – note that the issue describes a bug in qemu that would prevent it from sending `RESET_DEVICE`, which has [since been fixed](https://gitlab.com/qemu-project/qemu/-/commit/2688e8df60f5a655dc34c5e38523e425556f8483)).

Like all other protocol features, it is left to the back-end’s `VhostUserBackend::protocol_features()` implementation to decide whether to announce support for this or not.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
