### PR TITLE
Fix feature unification issues with gpu-socket feature

### DIFF
--- a/.buildkite/rust-vmm-ci-tests.json
+++ b/.buildkite/rust-vmm-ci-tests.json
@@ -22,7 +22,7 @@
     },
     {
       "test_name": "unittests-gnu-all-with-xen",
-      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
       "platform": [
         "x86_64",
         "aarch64"
@@ -30,7 +30,7 @@
     },
     {
       "test_name": "unittests-gnu-all-without-xen",
-      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy",
+      "command": "cargo test --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"
@@ -38,7 +38,7 @@
     },
     {
       "test_name": "unittests-musl-all-with-xen",
-      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
       "platform": [
         "x86_64",
         "aarch64"
@@ -46,7 +46,7 @@
     },
     {
       "test_name": "unittests-musl-all-without-xen",
-      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy",
+      "command": "cargo test --workspace --target {target_platform}-unknown-linux-musl --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"
@@ -54,7 +54,7 @@
     },
     {
       "test_name": "clippy-all-with-xen",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
         "aarch64"
@@ -62,7 +62,7 @@
     },
     {
       "test_name": "clippy-all-without-xen",
-      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-targets --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy -- -D warnings -D clippy::undocumented_unsafe_blocks",
       "platform": [
         "x86_64",
         "aarch64"
@@ -70,7 +70,7 @@
     },
     {
       "test_name": "check-warnings-all-with-xen",
-      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,xen",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,xen",
       "platform": [
         "x86_64",
         "aarch64"
@@ -78,7 +78,7 @@
     },
     {
       "test_name": "check-warnings-all-without-xen",
-      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,gpu-socket,vhost-user-backend,postcopy",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --workspace --no-default-features --features test-utils,vhost-vsock,vhost-kern,vhost-vdpa,vhost-net,vhost-user,vhost-user-frontend,vhost-user-backend,postcopy",
       "platform": [
         "x86_64",
         "aarch64"

--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 
 ### Fixed
+- [[#267](https://github.com/rust-vmm/vhost/pull/267)] Fix feature unification issues with gpu-socket feature.
 
 ## v0.16.0
 

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 [features]
 xen = ["vm-memory/xen", "vhost/xen"]
 postcopy = ["vhost/postcopy", "userfaultfd"]
-gpu-socket = ["vhost/gpu-socket"]
 
 [dependencies]
 libc = "0.2.39"

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -31,7 +31,6 @@ use vm_memory::bitmap::Bitmap;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
 
-#[cfg(feature = "gpu-socket")]
 use vhost::vhost_user::GpuBackend;
 
 use super::vring::VringT;
@@ -87,7 +86,6 @@ pub trait VhostUserBackend: Send + Sync {
     /// function.
     fn set_backend_req_fd(&self, _backend: Backend) {}
 
-    #[cfg(feature = "gpu-socket")]
     /// Set handler for communicating with the frontend by the gpu specific backend communication
     /// channel.
     ///
@@ -205,7 +203,6 @@ pub trait VhostUserBackendMut: Send + Sync {
     /// function.
     fn set_backend_req_fd(&mut self, _backend: Backend) {}
 
-    #[cfg(feature = "gpu-socket")]
     /// Set handler for communicating with the frontend by the gpu specific backend communication
     /// channel.
     ///
@@ -318,7 +315,6 @@ impl<T: VhostUserBackend> VhostUserBackend for Arc<T> {
         self.deref().set_backend_req_fd(backend)
     }
 
-    #[cfg(feature = "gpu-socket")]
     fn set_gpu_socket(&self, gpu_backend: GpuBackend) {
         self.deref().set_gpu_socket(gpu_backend)
     }
@@ -400,7 +396,6 @@ impl<T: VhostUserBackendMut> VhostUserBackend for Mutex<T> {
         self.lock().unwrap().set_backend_req_fd(backend)
     }
 
-    #[cfg(feature = "gpu-socket")]
     fn set_gpu_socket(&self, gpu_backend: GpuBackend) {
         self.lock().unwrap().set_gpu_socket(gpu_backend)
     }
@@ -485,7 +480,6 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
         self.write().unwrap().set_backend_req_fd(backend)
     }
 
-    #[cfg(feature = "gpu-socket")]
     fn set_gpu_socket(&self, gpu_backend: GpuBackend) {
         self.write().unwrap().set_gpu_socket(gpu_backend)
     }
@@ -610,7 +604,6 @@ pub mod tests {
 
         fn set_backend_req_fd(&mut self, _backend: Backend) {}
 
-        #[cfg(feature = "gpu-socket")]
         fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
 
         fn queues_per_thread(&self) -> Vec<u64> {

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -555,8 +555,10 @@ where
         self.backend.set_backend_req_fd(backend);
     }
 
-    fn set_gpu_socket(&mut self, gpu_backend: GpuBackend) {
-        self.backend.set_gpu_socket(gpu_backend);
+    fn set_gpu_socket(&mut self, gpu_backend: GpuBackend) -> VhostUserResult<()> {
+        self.backend
+            .set_gpu_socket(gpu_backend)
+            .map_err(VhostUserError::ReqHandlerError)
     }
 
     fn get_inflight_fd(

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -21,7 +21,6 @@ use vhost::vhost_user::message::{
     VhostUserMemoryRegion, VhostUserProtocolFeatures, VhostUserSingleMemoryRegion,
     VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
 };
-#[cfg(feature = "gpu-socket")]
 use vhost::vhost_user::GpuBackend;
 use vhost::vhost_user::{
     Backend, Error as VhostUserError, Result as VhostUserResult, VhostUserBackendReqHandlerMut,
@@ -556,7 +555,6 @@ where
         self.backend.set_backend_req_fd(backend);
     }
 
-    #[cfg(feature = "gpu-socket")]
     fn set_gpu_socket(&mut self, gpu_backend: GpuBackend) {
         self.backend.set_gpu_socket(gpu_backend);
     }

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -10,7 +10,6 @@ use std::thread;
 use vhost::vhost_user::message::{
     VhostUserConfigFlags, VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures,
 };
-use vhost::vhost_user::GpuBackend;
 use vhost::vhost_user::{Backend, Frontend, Listener, VhostUserFrontend};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
@@ -77,8 +76,6 @@ impl VhostUserBackendMut for MockVhostBackend {
 
         Ok(())
     }
-
-    fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
 
     fn update_memory(&mut self, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
         let mem = atomic_mem.memory();

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -10,7 +10,6 @@ use std::thread;
 use vhost::vhost_user::message::{
     VhostUserConfigFlags, VhostUserHeaderFlag, VhostUserInflight, VhostUserProtocolFeatures,
 };
-#[cfg(feature = "gpu-socket")]
 use vhost::vhost_user::GpuBackend;
 use vhost::vhost_user::{Backend, Frontend, Listener, VhostUserFrontend};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
@@ -79,7 +78,6 @@ impl VhostUserBackendMut for MockVhostBackend {
         Ok(())
     }
 
-    #[cfg(feature = "gpu-socket")]
     fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
 
     fn update_memory(&mut self, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 
 ### Fixed
+- [[#267](https://github.com/rust-vmm/vhost/pull/267)] Fix feature unification issues with gpu-socket feature.
 
 ## [0.12.0]
 

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -23,7 +23,6 @@ vhost-net = ["vhost-kern"]
 vhost-user = []
 vhost-user-frontend = ["vhost-user"]
 vhost-user-backend = ["vhost-user"]
-gpu-socket = ["vhost-user"]
 xen = ["vm-memory/xen"]
 postcopy = []
 

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -259,7 +259,9 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
         Ok(())
     }
 
-    fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
+    fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) -> Result<()> {
+        Ok(())
+    }
 
     fn get_inflight_fd(
         &mut self,

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -259,7 +259,6 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
         Ok(())
     }
 
-    #[cfg(feature = "gpu-socket")]
     fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) {}
 
     fn get_inflight_fd(

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -52,11 +52,8 @@ pub use self::backend_req_handler::{
 mod backend_req;
 #[cfg(feature = "vhost-user-backend")]
 pub use self::backend_req::Backend;
-#[cfg(feature = "gpu-socket")]
 mod gpu_backend_req;
-#[cfg(feature = "gpu-socket")]
 pub mod gpu_message;
-#[cfg(feature = "gpu-socket")]
 pub use self::gpu_backend_req::GpuBackend;
 
 /// Errors for vhost-user operations


### PR DESCRIPTION
### Summary of the PR

make `set_gpu_socket` method a default implementation and remove conditional compilation because cargo feature unification already defeats the purpose of the `gpu-socket` feature flag.

Fixes #265 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
