### PR TITLE
Add VHOST_USER_SHARED_OBJECT support

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#268]](https://github.com/rust-vmm/vhost/pull/268) Add support for `VHOST_USER_GET_SHARED_OBJECT`
 
 ### Changed
 

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -24,6 +24,7 @@ vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 nix = { version = "0.29", features = ["fs"] }
+uuid = { version = "1.8.0", features=["v4"] }
 vhost = { path = "../vhost", version = "0.13.0", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
 vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 tempfile = "3.2.0"

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -18,8 +18,9 @@ use crate::bitmap::{BitmapReplace, MemRegionBitmap, MmapLogReg};
 use userfaultfd::{Uffd, UffdBuilder};
 use vhost::vhost_user::message::{
     VhostTransferStateDirection, VhostTransferStatePhase, VhostUserConfigFlags, VhostUserLog,
-    VhostUserMemoryRegion, VhostUserProtocolFeatures, VhostUserSingleMemoryRegion,
-    VhostUserVirtioFeatures, VhostUserVringAddrFlags, VhostUserVringState,
+    VhostUserMemoryRegion, VhostUserProtocolFeatures, VhostUserSharedMsg,
+    VhostUserSingleMemoryRegion, VhostUserVirtioFeatures, VhostUserVringAddrFlags,
+    VhostUserVringState,
 };
 use vhost::vhost_user::GpuBackend;
 use vhost::vhost_user::{
@@ -572,6 +573,16 @@ where
         self.backend
             .set_gpu_socket(gpu_backend)
             .map_err(VhostUserError::ReqHandlerError)
+    }
+
+    fn get_shared_object(&mut self, uuid: VhostUserSharedMsg) -> VhostUserResult<File> {
+        match self.backend.get_shared_object(uuid) {
+            Ok(shared_file) => Ok(shared_file),
+            Err(e) => Err(VhostUserError::ReqHandlerError(io::Error::new(
+                io::ErrorKind::Other,
+                e,
+            ))),
+        }
     }
 
     fn get_inflight_fd(

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Added
+- [[#268]](https://github.com/rust-vmm/vhost/pull/268) Add support for `VHOST_USER_GET_SHARED_OBJECT`
 
 ### Changed
 

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -68,6 +68,7 @@ pub trait VhostUserBackendReqHandler {
     fn set_config(&self, offset: u32, buf: &[u8], flags: VhostUserConfigFlags) -> Result<()>;
     fn set_backend_req_fd(&self, _backend: Backend) {}
     fn set_gpu_socket(&self, _gpu_backend: GpuBackend) -> Result<()>;
+    fn get_shared_object(&self, uuid: VhostUserSharedMsg) -> Result<File>;
     fn get_inflight_fd(&self, inflight: &VhostUserInflight) -> Result<(VhostUserInflight, File)>;
     fn set_inflight_fd(&self, inflight: &VhostUserInflight, file: File) -> Result<()>;
     fn get_max_mem_slots(&self) -> Result<u64>;
@@ -129,6 +130,7 @@ pub trait VhostUserBackendReqHandlerMut {
     fn set_config(&mut self, offset: u32, buf: &[u8], flags: VhostUserConfigFlags) -> Result<()>;
     fn set_backend_req_fd(&mut self, _backend: Backend) {}
     fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) -> Result<()>;
+    fn get_shared_object(&mut self, uuid: VhostUserSharedMsg) -> Result<File>;
     fn get_inflight_fd(
         &mut self,
         inflight: &VhostUserInflight,
@@ -246,6 +248,10 @@ impl<T: VhostUserBackendReqHandlerMut> VhostUserBackendReqHandler for Mutex<T> {
 
     fn set_gpu_socket(&self, gpu_backend: GpuBackend) -> Result<()> {
         self.lock().unwrap().set_gpu_socket(gpu_backend)
+    }
+
+    fn get_shared_object(&self, uuid: VhostUserSharedMsg) -> Result<File> {
+        self.lock().unwrap().get_shared_object(uuid)
     }
 
     fn get_inflight_fd(&self, inflight: &VhostUserInflight) -> Result<(VhostUserInflight, File)> {
@@ -562,6 +568,26 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
                 self.check_request_size(&hdr, size, hdr.get_size() as usize)?;
                 let res = self.set_backend_req_fd(files);
                 self.send_ack_message(&hdr, res)?;
+            }
+            Ok(FrontendReq::GET_SHARED_OBJECT) => {
+                self.check_proto_feature(VhostUserProtocolFeatures::SHARED_OBJECT)?;
+                self.check_request_size(&hdr, size, hdr.get_size() as usize)?;
+                let msg = self.extract_request_body::<VhostUserSharedMsg>(&hdr, size, &buf)?;
+
+                let reply_hdr = self.new_reply_header::<VhostUserEmpty>(&hdr, 0)?;
+                match self.backend.get_shared_object(msg) {
+                    Ok(file) => {
+                        self.main_sock.send_message(
+                            &reply_hdr,
+                            &VhostUserEmpty,
+                            Some(&[file.as_raw_fd()]),
+                        )?;
+                    }
+                    Err(_) => {
+                        self.main_sock
+                            .send_message(&reply_hdr, &VhostUserEmpty, None)?;
+                    }
+                }
             }
             Ok(FrontendReq::GET_INFLIGHT_FD) => {
                 self.check_proto_feature(VhostUserProtocolFeatures::INFLIGHT_SHMFD)?;

--- a/vhost/src/vhost_user/dummy_backend.rs
+++ b/vhost/src/vhost_user/dummy_backend.rs
@@ -26,6 +26,7 @@ pub struct DummyBackendReqHandler {
     pub vring_started: [bool; MAX_QUEUE_NUM],
     pub vring_enabled: [bool; MAX_QUEUE_NUM],
     pub inflight_file: Option<File>,
+    pub shared_file: Option<File>,
 }
 
 impl DummyBackendReqHandler {
@@ -267,6 +268,13 @@ impl VhostUserBackendReqHandlerMut for DummyBackendReqHandler {
 
     fn set_gpu_socket(&mut self, _gpu_backend: GpuBackend) -> Result<()> {
         Ok(())
+    }
+
+    fn get_shared_object(&mut self, _uuid: VhostUserSharedMsg) -> Result<File> {
+        let file = tempfile::tempfile().unwrap();
+
+        self.shared_file = Some(file.try_clone().unwrap());
+        Ok(file)
     }
 
     fn get_inflight_fd(

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -58,6 +58,9 @@ pub trait VhostUserFrontend: VhostBackend {
     /// Setup backend communication channel.
     fn set_backend_request_fd(&mut self, fd: &dyn AsRawFd) -> Result<()>;
 
+    /// Retrieve a given dma-buf fd from a given backend
+    fn get_shared_object(&mut self, uuid: &VhostUserSharedMsg) -> Result<File>;
+
     /// Retrieve shared buffer for inflight I/O tracking.
     fn get_inflight_fd(
         &mut self,
@@ -482,6 +485,21 @@ impl VhostUserFrontend for Frontend {
         let fds = [fd.as_raw_fd()];
         let hdr = node.send_request_header(FrontendReq::SET_BACKEND_REQ_FD, Some(&fds))?;
         node.wait_for_ack(&hdr).map_err(|e| e.into())
+    }
+
+    fn get_shared_object(&mut self, uuid: &VhostUserSharedMsg) -> Result<File> {
+        let mut node = self.node();
+        node.check_proto_feature(VhostUserProtocolFeatures::SHARED_OBJECT)?;
+        if !uuid.is_valid() {
+            return error_code(VhostUserError::InvalidParam);
+        }
+        let hdr = node.send_request_with_body(FrontendReq::GET_SHARED_OBJECT, uuid, None)?;
+        let (_, files) = node.recv_reply_with_files::<VhostUserEmpty>(&hdr)?;
+
+        match take_single_file(files) {
+            Some(file) => Ok(file),
+            None => error_code(VhostUserError::IncorrectFds),
+        }
     }
 
     fn get_inflight_fd(

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -264,11 +264,13 @@ mod dummy_backend;
 
 #[cfg(all(test, feature = "vhost-user-frontend", feature = "vhost-user-backend"))]
 mod tests {
+    use message::VhostUserSharedMsg;
     use std::fs::File;
     use std::os::unix::io::AsRawFd;
     use std::path::{Path, PathBuf};
     use std::sync::{Arc, Barrier, Mutex};
     use std::thread;
+    use uuid::Uuid;
     use vmm_sys_util::rand::rand_alphanumerics;
     use vmm_sys_util::tempfile::TempFile;
 
@@ -404,6 +406,9 @@ mod tests {
             // set_inflight_fd()
             backend.handle_request().unwrap();
 
+            // get_shared_object()
+            backend.handle_request().unwrap();
+
             // get_queue_num()
             backend.handle_request().unwrap();
 
@@ -475,6 +480,11 @@ mod tests {
             .set_inflight_fd(&inflight_info, inflight_file.as_raw_fd())
             .unwrap();
 
+        frontend
+            .get_shared_object(&VhostUserSharedMsg {
+                uuid: Uuid::new_v4(),
+            })
+            .unwrap();
         let num = frontend.get_queue_num().unwrap();
         assert_eq!(num, 2);
 


### PR DESCRIPTION
### Summary of the PR

This PR adds support for the VHOST_USER_GET_SHARED_OBJECT message as described in the QEMU [specification](https://qemu-project.gitlab.io/qemu/interop/vhost-user.html) 
When the VHOST_USER_GET_SHARED_OBJECT is triggered from a vhost device, this message is expected to return a fd with reference to the resources specified by the uuid. This message can be used if a vhost device export resources (SHARED_OBJECT_ADD), and the UUID for that resource is found in the exporters cache.  This message allows forwarding of the fd to another vhost device in form of SHARED_OBJECT_LOOKUP message which imports the resources.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
