### PR TITLE
Yank vhost v0.12.0 and vhost-user-backend v0.16.0

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -15,7 +15,12 @@
 ### Fixed
 - [[#267](https://github.com/rust-vmm/vhost/pull/267)] Fix feature unification issues with gpu-socket feature.
 
-## v0.16.0
+## v0.16.0 - yanked
+
+This version got yanked because the `gpu_socket` feature introduced in this
+release was causing problems
+(see [#265](https://github.com/rust-vmm/vhost/issues/265)).
+Starting with the next version (v0.16.1), the `gpu_socket` feature was removed.
 
 ### Added
 - [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -15,7 +15,12 @@
 ### Fixed
 - [[#267](https://github.com/rust-vmm/vhost/pull/267)] Fix feature unification issues with gpu-socket feature.
 
-## [0.12.0]
+## [0.12.0] - yanked
+
+This version got yanked because the `gpu_socket` feature introduced in this
+release was causing problems
+(see [#265](https://github.com/rust-vmm/vhost/issues/265)).
+Starting with the next version (v0.12.1), the `gpu_socket` feature was removed.
 
 ### Added
 - [[#241]](https://github.com/rust-vmm/vhost/pull/241) Add shared objects support


### PR DESCRIPTION
### Summary of the PR

These versions got yanked because the `gpu_socket` feature introduced
in this release was causing problems (see [#265](https://github.com/rust-vmm/vhost/issues/265)).
Starting with the next versions, the `gpu_socket` feature was removed.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
