### PR TITLE
Prepare vhost v0.13.0 and vhost-user-backend v0.17.0 releases

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -2,13 +2,20 @@
 ## [Unreleased]
 
 ### Added
-- [[#266]](https://github.com/rust-vmm/vhost/pull/266) Add support for `VHOST_USER_RESET_DEVICE`
 
 ### Changed
 
 ### Deprecated
 
 ### Fixed
+
+## v0.17.0
+
+### Added
+- [[#266]](https://github.com/rust-vmm/vhost/pull/266) Add support for `VHOST_USER_RESET_DEVICE`
+
+### Changed
+- [[#269]](https://github.com/rust-vmm/vhost/pull/269) Update vm-memory to 0.16.0 and virtio-queue to 0.13.0
 
 ## v0.16.1
 

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -16,7 +16,7 @@ postcopy = ["vhost/postcopy", "userfaultfd"]
 libc = "0.2.39"
 log = "0.4.17"
 userfaultfd = { version = "0.8.1", optional = true }
-vhost = { path = "../vhost", version = "0.12.1", features = ["vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.13.0", features = ["vhost-user-backend"] }
 virtio-bindings = { workspace = true }
 virtio-queue = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
@@ -24,6 +24,6 @@ vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 nix = { version = "0.29", features = ["fs"] }
-vhost = { path = "../vhost", version = "0.12.1", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
+vhost = { path = "../vhost", version = "0.13.0", features = ["test-utils", "vhost-user-frontend", "vhost-user-backend"] }
 vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 tempfile = "3.2.0"

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -2,13 +2,20 @@
 ## [Unreleased]
 
 ### Added
-- [[#266]](https://github.com/rust-vmm/vhost/pull/266) Add support for `VHOST_USER_RESET_DEVICE`
 
 ### Changed
 
 ### Deprecated
 
 ### Fixed
+
+## [0.13.0]
+
+### Added
+- [[#266]](https://github.com/rust-vmm/vhost/pull/266) Add support for `VHOST_USER_RESET_DEVICE`
+
+### Changed
+- [[#269]](https://github.com/rust-vmm/vhost/pull/269) Update vm-memory to 0.16.0 and virtio-queue to 0.13.0
 
 ## [0.12.1]
 

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost"
-version = "0.12.1"
+version = "0.13.0"
 keywords = ["vhost", "vhost-user", "virtio", "vdpa"]
 description = "a pure rust library for vdpa, vhost and vhost-user"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
### Summary of the PR

This release adds support for `VHOST_USER_RESET_DEVICE` and updates vm-memory to 0.16.0 and virtio-queue to 0.13.0.

Closes #275 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
