### PR TITLE
vhost: Refactor reply header initialization in POSTCOPY_ADVISE

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 
 ### Fixed
+- [[#277]](https://github.com/rust-vmm/vhost/pull/277) vhost: Fix reply header for error case in POSTCOPY_ADVISE
 
 ## v0.13.0
 


### PR DESCRIPTION

### Summary of the PR

In BackendReqHandler::POSTCOPY_ADVISE, refactor the reply header
initialization for clarity and reuse.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
