### PR TITLE
vhost-user-backend: fix clippy warnings

### DIFF
--- a/vhost-user-backend/src/bitmap.rs
+++ b/vhost-user-backend/src/bitmap.rs
@@ -106,7 +106,7 @@ impl BitmapReplace for BitmapMmapRegion {
 
 impl BitmapSlice for BitmapMmapRegion {}
 
-impl<'a> WithBitmapSlice<'a> for BitmapMmapRegion {
+impl WithBitmapSlice<'_> for BitmapMmapRegion {
     type S = Self;
 }
 

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -356,7 +356,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         if num == 0 || num as usize > self.max_queue_size {
             return Err(VhostUserError::InvalidParam);
@@ -377,7 +377,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         if !self.mappings.is_empty() {
             let desc_table = self.vmm_va_to_gpa(descriptor).map_err(|e| {
@@ -418,7 +418,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         vring.set_queue_next_avail(base as u16);
 
@@ -429,7 +429,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         // Quote from vhost-user specification:
         // Client must start ring upon receiving a kick (that is, detecting
@@ -463,7 +463,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         // SAFETY: EventFd requires that it has sole ownership of its fd. So
         // does File, so this is safe.
@@ -482,7 +482,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         vring.set_call(file);
 
@@ -497,7 +497,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         vring.set_err(file);
 
@@ -528,7 +528,7 @@ where
         let vring = self
             .vrings
             .get(index as usize)
-            .ok_or_else(|| VhostUserError::InvalidParam)?;
+            .ok_or(VhostUserError::InvalidParam)?;
 
         // Backend must not pass data to/from the backend until ring is
         // enabled by VHOST_USER_SET_VRING_ENABLE with parameter 1,


### PR DESCRIPTION
### Summary of the PR

New clippy version in the CI highlighted some code to improve. This patch is generated using `clippy --fix ...`.

Fixed 2 type of warnings:
```
1 - error: the following explicit lifetimes could be elided: 'a
       --> vhost-user-backend/src/bitmap.rs:109:6
        |
    109 | impl<'a> WithBitmapSlice<'a> for BitmapMmapRegion {

2 - error: unnecessary closure used to substitute value for `Option::None`
       --> vhost-user-backend/src/handler.rs:356:21
        |
    356 |           let vring = self
        |  _____________________^
    357 | |             .vrings
    358 | |             .get(index as usize)
    359 | |             .ok_or_else(|| VhostUserError::InvalidParam)?;
```


*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
