### PR TITLE
vhost: fix clippy warnings on Rust 1.85

### DIFF
--- a/vhost/src/vhost_kern/mod.rs
+++ b/vhost/src/vhost_kern/mod.rs
@@ -78,19 +78,19 @@ pub trait VhostKernBackend: AsRawFd {
         let used_ring_size = 6 + 8 * u64::from(queue_size) as GuestUsize;
         if GuestAddress(config_data.desc_table_addr)
             .checked_add(desc_table_size)
-            .map_or(true, |v| !m.address_in_range(v))
+            .is_none_or(|v| !m.address_in_range(v))
         {
             return false;
         }
         if GuestAddress(config_data.avail_ring_addr)
             .checked_add(avail_ring_size)
-            .map_or(true, |v| !m.address_in_range(v))
+            .is_none_or(|v| !m.address_in_range(v))
         {
             return false;
         }
         if GuestAddress(config_data.used_ring_addr)
             .checked_add(used_ring_size)
-            .map_or(true, |v| !m.address_in_range(v))
+            .is_none_or(|v| !m.address_in_range(v))
         {
             return false;
         }


### PR DESCRIPTION
### Summary of the PR

Our CI is being upgraded to Rust 1.85 and this will produce new warnings from clippy like this one:
```
  error: this `map_or` can be simplified
    --> vhost/src/vhost_kern/mod.rs:79:12
     |
  79 |           if GuestAddress(config_data.desc_table_addr)
     |  ____________^
  80 | |             .checked_add(desc_table_size)
  81 | |             .map_or(true, |v| !m.address_in_range(v))
     | |_____________________________________________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
     = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`
  help: use is_none_or instead
     |
  79 ~         if GuestAddress(config_data.desc_table_addr)
  80 +             .checked_add(desc_table_size).is_none_or(|v| !m.address_in_range(v))
     |
```
Apply the advice using `cargo clippy --fix`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
