### PR TITLE
vhost_user: format links in docs correctly

### DIFF
--- a/vhost/src/vhost_user/gpu_backend_req.rs
+++ b/vhost/src/vhost_user/gpu_backend_req.rs
@@ -100,7 +100,7 @@ impl BackendInternal {
 
 /// Proxy for sending messages from the backend to the fronted
 /// over the socket obtained from VHOST_USER_GPU_SET_SOCKET.
-/// The protocol is documented here: https://www.qemu.org/docs/master/interop/vhost-user-gpu.html
+/// The protocol is documented here: <https://www.qemu.org/docs/master/interop/vhost-user-gpu.html>
 #[derive(Clone)]
 pub struct GpuBackend {
     // underlying Unix domain socket for communication

--- a/vhost/src/vhost_user/gpu_message.rs
+++ b/vhost/src/vhost_user/gpu_message.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implementation parts of the protocol on the socket from VHOST_USER_SET_GPU_SOCKET
-//! see: https://www.qemu.org/docs/master/interop/vhost-user-gpu.html
+//! see: <https://www.qemu.org/docs/master/interop/vhost-user-gpu.html>
 
 use super::enum_value;
 use crate::vhost_user::message::{MsgHeader, Req, VhostUserMsgValidator};


### PR DESCRIPTION
### Summary of the PR

This resolves a rustdoc warning, and makes the links appear as links in the rendered documentation.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
