### PR TITLE
vhost_user: fix replies without GET_PROTOCOL_FEATURES

### DIFF
--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -59,7 +59,8 @@ impl VhostUserBackendMut for MockVhostBackend {
     }
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::all()
+        // Exclude REPLY_ACK to test that it is automatically added.
+        VhostUserProtocolFeatures::all() - VhostUserProtocolFeatures::REPLY_ACK
     }
 
     fn reset_device(&mut self) {

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -5,6 +5,10 @@
 - [[#268]](https://github.com/rust-vmm/vhost/pull/268) Add support for `VHOST_USER_GET_SHARED_OBJECT`
 
 ### Changed
+- [[#290]](https://github.com/rust-vmm/vhost/pull/290) Backends now
+  always support `VHOST_USER_PROTOCOL_F_REPLY_ACK`, without the
+  `VhostUserBackendReqHandler` implementation having to include it in
+  the features returned from `get_protocol_features`.
 
 ### Deprecated
 


### PR DESCRIPTION
### Summary of the PR

I observed hangs in the following situation when using Cloud Hypervisor with virtiofsd:

1. Start virtiofsd
2. Start Cloud Hypervisor instance 1, connected to virtiofsd.
3. Start Cloud Hypervisor instance 2, waiting for migration.
4. Migrate VM from Cloud Hypervisor instance 1 to 2.
5. Start virtiofsd again.

The hangs happened because Cloud Hypervisor remembered, as part of the migration data, which vhost-user protocol features the backend for its fs device supported.  Instance 2 therefore never sent `GET_PROTOCOL_FEATURES` to the second invocation of virtiofsd.  This should work, but it didn't, because `update_reply_ack_flag()` checked whether self.protocol_features contained `GET_PROTOCOL_FEATURES`, but `self.protocol_features` is only filled in when `GET_PROTOCOL_FEATURES` is called.  As a result, Cloud Hypervisor expected a reply that virtiofsd would never send.

Since `REPLY_ACK` is handled entirely by the vhost-user library, and not by the backend, there's no need to ask the backend whether it supports `REPLY_ACK` in the first place, so we can just drop the check for that from `update_reply_ack_flag()`.  We know that we always support it, so we just need to check whether the backend has acked it.  This fixes the hang described above.

Since we will now always reply if the backend acks the feature, `REPLY_ACK` is now always included in the set of features returned by `GET_PROTOCOL_FEATURES`, just like with `XEN_MMAP` (when enabled).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
