### PR TITLE
Added function get_enabled to export vring enable status.

### DIFF
--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -61,6 +61,9 @@ pub trait VringT<M: GuestAddressSpace>:
     /// Set vring enabled state.
     fn set_enabled(&self, enabled: bool);
 
+    /// Get vring enabled state.
+    fn get_enabled(&self) -> bool;
+
     /// Set queue addresses for descriptor table, available ring and used ring.
     fn set_queue_info(
         &self,
@@ -172,6 +175,10 @@ impl<M: GuestAddressSpace> VringState<M> {
     /// Set vring enabled state.
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
+    }
+
+    pub fn get_enabled(&self) -> bool {
+        self.enabled
     }
 
     /// Set queue addresses for descriptor table, available ring and used ring.
@@ -327,6 +334,10 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringMutex<M> {
         self.lock().set_enabled(enabled)
     }
 
+    fn get_enabled(&self) -> bool {
+        self.get_ref().enabled
+    }
+
     fn set_queue_info(
         &self,
         desc_table: u64,
@@ -440,6 +451,10 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringRwLock<M> {
 
     fn set_enabled(&self, enabled: bool) {
         self.write_lock().set_enabled(enabled)
+    }
+
+    fn get_enabled(&self) -> bool {
+        self.get_ref().enabled
     }
 
     fn set_queue_info(


### PR DESCRIPTION
### Summary of the PR

The vring is disabled and RX/TX queue is set to
not-ready during snapshot. But vhost-device process
keeps access vring and queue after snapshot which
caused system hang. We need to export vring enabled
and disabled status for snapshot feature so that
the vhost-device would skip vring/queue access
after snapshot to avoid hang.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
