### PR TITLE
set_log_base: use MmapRegion::bitmap() directly

### DIFF
--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -30,10 +30,7 @@ use vhost::vhost_user::{
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Error as VirtQueError, QueueT};
 use vm_memory::mmap::NewBitmap;
-use vm_memory::{
-    GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap, GuestMemoryRegion,
-    GuestRegionMmap,
-};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
 use vmm_sys_util::epoll::EventSet;
 
 use super::backend::VhostUserBackend;
@@ -788,7 +785,7 @@ where
         }
 
         for (region, bitmap) in bitmaps {
-            region.bitmap().replace(bitmap);
+            (*region).bitmap().replace(bitmap);
         }
 
         Ok(())


### PR DESCRIPTION
### Summary of the PR

For use in QEMU, I would like GuestMemoryRegion to return a BitmapSlice instead of a &Bitmap ([rust-vmm/vm-memory#324](https://github.com/rust-vmm/vm-memory/pull/324)).  This adds some flexibility that QEMU needs in order to support a single global dirty bitmap that is sliced by the various GuestMemoryRegions.

However, this removes access to the BitmapReplace trait, because it is of course not possible to replace a slice of the bitmap only.  Fortunately, vhost is built around the GM<> type alias, which has a pluggable bitmap type but hardcodes the backend:

    type GM<B> = GuestMemoryAtomic<GuestMemoryMmap<B>>;

and therefore `region` is known to be a GuestRegionMmap.  Adding a single dereference of the GuestRegionMmap returns the MmapRegion to which the bitmap is attached, thus calling MmapRegion::bitmap() instead of <GuestRegionMmap as GuestRegion>::bitmap().

The change works either with or without the changes in vm-memory.
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
