### PR TITLE
Update virtio-queue and virtio-bindings to latest version and prepare for new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-virtio-bindings = "0.2.1"
-virtio-queue = "0.14.0"
+virtio-bindings = "0.2.5"
+virtio-queue = "0.15.0"
 vm-memory = "0.16.2"
 vmm-sys-util = "0.14.0"

--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### Deprecated
 ### Fixed
 
+## v0.19.0
+
+### Changed
+- [[299]](https://github.com/rust-vmm/vhost/pull/299) Updated virtio-queue to v0.15.0 and virtio-bindings to v0.2.5
+
 ## v0.18.0
 
 ### Added

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-user-backend"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The Cloud Hypervisor Authors"]
 keywords = ["vhost-user", "virtio"]
 description = "A framework to build vhost-user backend service daemon"


### PR DESCRIPTION
### Summary of the PR

Bump virtio-queue from v0.14.0 to v0.15.0

Bump virtio-bindings from v0.2.1 to v0.2.5

Also prepare for a new release of the crate.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
