### PR TITLE
vhost: Fix clippy warning from nightly compiler

### DIFF
--- a/vhost-user-backend/src/bitmap.rs
+++ b/vhost-user-backend/src/bitmap.rs
@@ -87,7 +87,7 @@ impl Bitmap for BitmapMmapRegion {
             .is_some_and(|bitmap| bitmap.dirty_at(self.base_address.saturating_add(offset)))
     }
 
-    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S {
+    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice<'_>>::S {
         Self {
             inner: Arc::clone(&self.inner),
             base_address: self.base_address.saturating_add(offset),

--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -275,7 +275,7 @@ pub struct VringMutex<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>>
 
 impl<M: GuestAddressSpace> VringMutex<M> {
     /// Get a mutable guard to the underlying raw `VringState` object.
-    fn lock(&self) -> MutexGuard<VringState<M>> {
+    fn lock(&self) -> MutexGuard<'_, VringState<M>> {
         self.state.lock().unwrap()
     }
 }
@@ -295,11 +295,11 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringMutex<M> {
         })
     }
 
-    fn get_ref(&self) -> <Self as VringStateGuard<M>>::G {
+    fn get_ref(&self) -> <Self as VringStateGuard<'_, M>>::G {
         self.state.lock().unwrap()
     }
 
-    fn get_mut(&self) -> <Self as VringStateMutGuard<M>>::G {
+    fn get_mut(&self) -> <Self as VringStateMutGuard<'_, M>>::G {
         self.lock()
     }
 
@@ -390,7 +390,7 @@ pub struct VringRwLock<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>
 
 impl<M: GuestAddressSpace> VringRwLock<M> {
     /// Get a mutable guard to the underlying raw `VringState` object.
-    fn write_lock(&self) -> RwLockWriteGuard<VringState<M>> {
+    fn write_lock(&self) -> RwLockWriteGuard<'_, VringState<M>> {
         self.state.write().unwrap()
     }
 }
@@ -410,11 +410,11 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringRwLock<M> {
         })
     }
 
-    fn get_ref(&self) -> <Self as VringStateGuard<M>>::G {
+    fn get_ref(&self) -> <Self as VringStateGuard<'_, M>>::G {
         self.state.read().unwrap()
     }
 
-    fn get_mut(&self) -> <Self as VringStateMutGuard<M>>::G {
+    fn get_mut(&self) -> <Self as VringStateMutGuard<'_, M>>::G {
         self.write_lock()
     }
 

--- a/vhost/src/vhost_user/backend_req.rs
+++ b/vhost/src/vhost_user/backend_req.rs
@@ -97,7 +97,7 @@ impl Backend {
         }
     }
 
-    fn node(&self) -> MutexGuard<BackendInternal> {
+    fn node(&self) -> MutexGuard<'_, BackendInternal> {
         self.node.lock().unwrap()
     }
 

--- a/vhost/src/vhost_user/gpu_backend_req.rs
+++ b/vhost/src/vhost_user/gpu_backend_req.rs
@@ -117,7 +117,7 @@ impl GpuBackend {
         }
     }
 
-    fn node(&self) -> MutexGuard<BackendInternal> {
+    fn node(&self) -> MutexGuard<'_, BackendInternal> {
         self.node.lock().unwrap()
     }
 


### PR DESCRIPTION
### Summary of the PR

There is a new warning reported by nightly compiler about mismatched lifetime syntaxes. Add the missing lifetime where ever required.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
