### PR TITLE
vhost: Fix building docs

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 ### Deprecated
 ### Fixed
+- [[#304]](https://github.com/rust-vmm/vhost/pull/304) Fix building docs.
 
 ## v0.14.0
 

--- a/vhost/src/lib.rs
+++ b/vhost/src/lib.rs
@@ -54,7 +54,7 @@ pub mod vsock;
 /// Due to the way `xen` handles memory mappings we can not combine it with
 /// `postcopy` feature which relies on persistent memory mappings. Thus we
 /// disallow enabling both features at the same time.
-#[cfg(all(feature = "postcopy", feature = "xen"))]
+#[cfg(all(not(doc), feature = "postcopy", feature = "xen"))]
 compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
 
 /// Error codes for vhost operations


### PR DESCRIPTION
Building docs (as on docs.rs) has been broken since 8ee8739. This commit introduces POSTCOPY and made this feature mutually exclusive with xen.

As docs are build for all features the corresponding check will be triggered and the docs can not be built.

This patch extends the check to allow both "postcopy" and "xen" to be enabled when building docs.

### Summary of the PR

docs.rs is useful when working with any rust crate. This PR fixes building the docs.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
