### PR TITLE
Replace Eventfd with EventNotifier/EventConsumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ members = [
 virtio-bindings = "0.2.6"
 virtio-queue = "0.16.0"
 vm-memory = "0.16.2"
-vmm-sys-util = "0.14.0"
+vmm-sys-util = "0.15.0"

--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 ### Changed
+- [[#308](https://github.com/rust-vmm/vhost/pull/308)] Replace Eventfd with EventNotifier/EventConsumer.
+
 ### Deprecated
 ### Fixed
 

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -30,7 +30,7 @@ use vhost::vhost_user::message::{
 use vhost::vhost_user::Backend;
 use vm_memory::bitmap::Bitmap;
 use vmm_sys_util::epoll::EventSet;
-use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::event::{EventConsumer, EventNotifier};
 
 use vhost::vhost_user::GpuBackend;
 
@@ -132,7 +132,8 @@ pub trait VhostUserBackend: Send + Sync {
     ///
     /// The returned `EventFd` will be monitored for IO events. When the
     /// returned EventFd is written to, the worker thread will exit.
-    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+    // TODO: Refine this API to return only EventNotifier.
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
         None
     }
 
@@ -275,7 +276,8 @@ pub trait VhostUserBackendMut: Send + Sync {
     /// If an (`EventFd`, `token`) pair is returned, the returned `EventFd` will be monitored for IO
     /// events by using epoll with the specified `token`. When the returned EventFd is written to,
     /// the worker thread will exit.
-    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+    // TODO: Refine this API to return only EventNotifier.
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
         None
     }
 
@@ -382,7 +384,7 @@ impl<T: VhostUserBackend> VhostUserBackend for Arc<T> {
         self.deref().queues_per_thread()
     }
 
-    fn exit_event(&self, thread_index: usize) -> Option<EventFd> {
+    fn exit_event(&self, thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
         self.deref().exit_event(thread_index)
     }
 
@@ -471,7 +473,7 @@ impl<T: VhostUserBackendMut> VhostUserBackend for Mutex<T> {
         self.lock().unwrap().queues_per_thread()
     }
 
-    fn exit_event(&self, thread_index: usize) -> Option<EventFd> {
+    fn exit_event(&self, thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
         self.lock().unwrap().exit_event(thread_index)
     }
 
@@ -563,7 +565,7 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
         self.read().unwrap().queues_per_thread()
     }
 
-    fn exit_event(&self, thread_index: usize) -> Option<EventFd> {
+    fn exit_event(&self, thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
         self.read().unwrap().exit_event(thread_index)
     }
 
@@ -599,16 +601,16 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
 pub mod tests {
     use super::*;
     use crate::VringRwLock;
-    use libc::EFD_NONBLOCK;
     use std::sync::Mutex;
     use uuid::Uuid;
     use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
     pub struct MockVhostBackend {
         events: u64,
         event_idx: bool,
         acked_features: u64,
-        exit_event_fds: Vec<EventFd>,
+        exit_event_fds: Vec<(EventConsumer, EventNotifier)>,
     }
 
     impl MockVhostBackend {
@@ -624,7 +626,10 @@ pub mod tests {
             // order to allow tests maximum flexibility in checking whether
             // signals arrived or not.
             backend.exit_event_fds = (0..backend.queues_per_thread().len())
-                .map(|_| EventFd::new(EFD_NONBLOCK).unwrap())
+                .map(|_| {
+                    new_event_consumer_and_notifier(EventFlag::NONBLOCK)
+                        .expect("Failed to new EventNotifier and EventConsumer")
+                })
                 .collect();
 
             backend
@@ -695,13 +700,13 @@ pub mod tests {
             vec![1, 1]
         }
 
-        fn exit_event(&self, thread_index: usize) -> Option<EventFd> {
-            Some(
-                self.exit_event_fds
-                    .get(thread_index)?
-                    .try_clone()
-                    .expect("Could not clone exit eventfd"),
-            )
+        fn exit_event(&self, thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
+            self.exit_event_fds.get(thread_index).map(|(s, r)| {
+                (
+                    s.try_clone().expect("Failed to clone EventConsumer"),
+                    r.try_clone().expect("Failed to clone EventNotifier"),
+                )
+            })
         }
 
         fn handle_event(

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
                 let fd = backend.exit_event(thread_id).unwrap();
                 // Reading from exit fd should fail since nothing was written yet
                 assert_eq!(
-                    fd.read().unwrap_err().raw_os_error().unwrap(),
+                    fd.0.consume().unwrap_err().raw_os_error().unwrap(),
                     EAGAIN,
                     "exit event should not have been raised yet!"
                 );
@@ -365,7 +365,7 @@ mod tests {
         let backend = backend.lock().unwrap();
         for thread_id in 0..backend.queues_per_thread().len() {
             let fd = backend.exit_event(thread_id).unwrap();
-            assert!(fd.read().is_ok(), "No exit event was raised!");
+            assert!(fd.0.consume().is_ok(), "No exit event was raised!");
         }
     }
 }

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -18,6 +18,9 @@ use vm_memory::{
     FileOffset, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap,
 };
 use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::event::{
+    new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,
+};
 use vmm_sys_util::eventfd::EventFd;
 
 struct MockVhostBackend {
@@ -105,10 +108,11 @@ impl VhostUserBackendMut for MockVhostBackend {
         vec![1, 1]
     }
 
-    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
-        let event_fd = EventFd::new(0).unwrap();
-
-        Some(event_fd)
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
+        Some(
+            new_event_consumer_and_notifier(EventFlag::empty())
+                .expect("Failed to create EventConsumer and EventNotifier"),
+        )
     }
 
     fn handle_event(

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -760,9 +760,13 @@ mod tests {
             .unwrap();
         assert_eq!(len, 4);
 
-        let (bytes, buf4) = backend.recv_data(2).unwrap();
-        assert_eq!(bytes, 2);
-        assert_eq!(&buf1[..2], &buf4[..]);
+        if cfg!(any(target_os = "linux", target_os = "android")) {
+            let _err = backend.recv_data(2).unwrap_err();
+        } else {
+            let (bytes, buf4) = backend.recv_data(2).unwrap();
+            assert_eq!(bytes, 2);
+            assert_eq!(&buf1[..2], &buf4[..]);
+        }
         let (bytes, buf2, files) = backend.recv_into_buf(0x2).unwrap();
         assert_eq!(bytes, 2);
         assert_eq!(&buf1[2..], &buf2[..]);
@@ -817,12 +821,21 @@ mod tests {
             .unwrap();
         assert_eq!(len, 4);
 
-        let (bytes, _) = backend.recv_data(5).unwrap();
-        assert_eq!(bytes, 5);
+        if cfg!(any(target_os = "linux", target_os = "android")) {
+            let _err = backend.recv_data(5).unwrap_err();
+        } else {
+            let (bytes, _) = backend.recv_data(5).unwrap();
+            assert_eq!(bytes, 4);
+        }
 
         let (bytes, _, files) = backend.recv_into_buf(0x4).unwrap();
-        assert_eq!(bytes, 3);
-        assert!(files.is_none());
+        if cfg!(any(target_os = "linux", target_os = "android")) {
+            assert_eq!(bytes, 3);
+            assert!(files.is_none());
+        } else {
+            assert_eq!(bytes, 4);
+            assert!(files.is_some());
+        }
 
         // If the target fd array is too small, extra file descriptors will get lost.
         let len = frontend


### PR DESCRIPTION
### Summary of the PR

Eventfd is Linux-specific. To support more platforms, we replace it with
the EventNotifier/EventConsumer abstractions.
EventSender and EventReceiver are wrappers that encapsulate eventfd functionality
Use pipefd to replace eventfd in the test.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ x ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ x ] All added/changed functionality has a corresponding unit/integration
  test.
- [ x ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ x ] Any newly added `unsafe` code is properly documented.
