### PR TITLE
vhost: `impl From<UnixListener> for Listener`

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- [[#311]](https://github.com/rust-vmm/vhost/pull/311) Implement
+  `From<UnixListener>` for `vhost_user::Listener`.
+
 ### Changed
 ### Deprecated
 ### Fixed

--- a/vhost/src/vhost_user/connection.rs
+++ b/vhost/src/vhost_user/connection.rs
@@ -86,10 +86,13 @@ impl AsRawFd for Listener {
 
 impl FromRawFd for Listener {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Listener {
-            fd: UnixListener::from_raw_fd(fd),
-            path: None,
-        }
+        Self::from(UnixListener::from_raw_fd(fd))
+    }
+}
+
+impl From<UnixListener> for Listener {
+    fn from(fd: UnixListener) -> Self {
+        Self { fd, path: None }
     }
 }
 


### PR DESCRIPTION
### Summary of the PR

It was already possible to do this as follows:

```rust
unsafe { Listener::from_raw_fd(listener.into_raw_fd()) }
```

This just factors the `From` implementation out of the `FromRawFd` implementation so it's possible to do the conversion without an unnecessary `unsafe` in application code.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test. <ins>(Covered by the existing test for `FromRawFd`.)</ins>
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
