### PR TITLE
Use mio to replace Epoll

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [[#339]](https://github.com/rust-vmm/vhost/pull/339) Add support for `GET_SHMEM_CONFIG` message
 
 ### Changed
+- [[316](https://github.com/rust-vmm/vhost/pull/316)] Use mio to replace Epoll. Expose event_loop::EventSet.
+
 ### Deprecated
 ### Fixed
 

--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -20,6 +20,7 @@ postcopy = ["vhost/postcopy", "userfaultfd"]
 libc = "0.2.39"
 log = "0.4.17"
 userfaultfd = { version = "0.9.0", optional = true }
+mio = { version = "1.0.4", features = ["os-poll", "os-ext"] }
 vhost = { path = "../vhost", version = "0.15.0", features = ["vhost-user-backend"] }
 virtio-bindings = { workspace = true }
 virtio-queue = { workspace = true }

--- a/vhost-user-backend/README.md
+++ b/vhost-user-backend/README.md
@@ -22,7 +22,7 @@ where
     pub fn new(name: String, backend: S, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap<B>>) -> Result<Self>;
     pub fn start(&mut self, listener: Listener) -> Result<()>;
     pub fn wait(&mut self) -> Result<()>;
-    pub fn get_epoll_handlers(&self) -> Vec<Arc<VringEpollHandler<S, V, B>>>;
+    pub fn get_poll_handlers(&self) -> Vec<Arc<VringPollHandler<S, V, B>>>;
 }
 ```
 

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -29,13 +29,14 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::Backend;
 use vm_memory::bitmap::Bitmap;
-use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::event::{EventConsumer, EventNotifier};
 
 use vhost::vhost_user::GpuBackend;
 
 use super::vring::VringT;
 use super::GM;
+
+use crate::EventSet;
 
 /// Trait with interior mutability for vhost user backend servers to implement concrete services.
 ///
@@ -828,7 +829,7 @@ pub mod tests {
 
         let vring = VringRwLock::new(mem, 0x1000).unwrap();
         backend
-            .handle_event(0x1, EventSet::IN, &[vring], 0)
+            .handle_event(0x1, EventSet::Readable, &[vring], 0)
             .unwrap();
 
         backend.reset_device();

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -144,7 +144,7 @@ pub trait VhostUserBackend: Send + Sync {
     /// do with events happening on custom listeners.
     fn handle_event(
         &self,
-        device_event: u16,
+        device_event: usize,
         evset: EventSet,
         vrings: &[Self::Vring],
         thread_id: usize,
@@ -295,7 +295,7 @@ pub trait VhostUserBackendMut: Send + Sync {
     /// do with events happening on custom listeners.
     fn handle_event(
         &mut self,
-        device_event: u16,
+        device_event: usize,
         evset: EventSet,
         vrings: &[Self::Vring],
         thread_id: usize,
@@ -404,7 +404,7 @@ impl<T: VhostUserBackend> VhostUserBackend for Arc<T> {
 
     fn handle_event(
         &self,
-        device_event: u16,
+        device_event: usize,
         evset: EventSet,
         vrings: &[Self::Vring],
         thread_id: usize,
@@ -497,7 +497,7 @@ impl<T: VhostUserBackendMut> VhostUserBackend for Mutex<T> {
 
     fn handle_event(
         &self,
-        device_event: u16,
+        device_event: usize,
         evset: EventSet,
         vrings: &[Self::Vring],
         thread_id: usize,
@@ -593,7 +593,7 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
 
     fn handle_event(
         &self,
-        device_event: u16,
+        device_event: usize,
         evset: EventSet,
         vrings: &[Self::Vring],
         thread_id: usize,
@@ -741,7 +741,7 @@ pub mod tests {
 
         fn handle_event(
             &mut self,
-            _device_event: u16,
+            _device_event: usize,
             _evset: EventSet,
             _vrings: &[VringRwLock],
             _thread_id: usize,

--- a/vhost-user-backend/src/event_loop.rs
+++ b/vhost-user-backend/src/event_loop.rs
@@ -184,10 +184,10 @@ where
                     }
                 };
 
-                let ev_type = event.data() as u16;
+                let ev_type = event.data();
 
                 // handle_event() returns true if an event is received from the exit event fd.
-                if self.handle_event(ev_type, evset)? {
+                if self.handle_event(ev_type as usize, evset)? {
                     break 'epoll;
                 }
             }
@@ -196,13 +196,13 @@ where
         Ok(())
     }
 
-    fn handle_event(&self, device_event: u16, evset: EventSet) -> VringEpollResult<bool> {
-        if self.exit_event_fd.is_some() && device_event as usize == self.backend.num_queues() {
+    fn handle_event(&self, device_event: usize, evset: EventSet) -> VringEpollResult<bool> {
+        if self.exit_event_fd.is_some() && device_event == self.backend.num_queues() {
             return Ok(true);
         }
 
-        if (device_event as usize) < self.vrings.len() {
-            let vring = &self.vrings[device_event as usize];
+        if device_event < self.vrings.len() {
+            let vring = &self.vrings[device_event];
             let enabled = vring
                 .read_kick()
                 .map_err(VringEpollError::HandleEventReadKick)?;

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -222,7 +222,7 @@ where
                         if let Err(e) = self.handlers[thread_index].register_event(
                             fd.as_raw_fd(),
                             EventSet::IN,
-                            u64::from(evt_idx),
+                            evt_idx as usize,
                         ) {
                             if e.kind() != io::ErrorKind::AlreadyExists {
                                 // This could happen if we're asked by the frontend to enable an
@@ -234,7 +234,7 @@ where
                         let _ = self.handlers[thread_index].unregister_event(
                             fd.as_raw_fd(),
                             EventSet::IN,
-                            u64::from(evt_idx),
+                            evt_idx as usize,
                         );
                     }
                     break;

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -23,7 +23,7 @@ mod backend;
 pub use self::backend::{VhostUserBackend, VhostUserBackendMut};
 
 mod event_loop;
-pub use self::event_loop::VringEpollHandler;
+pub use self::event_loop::{EventSet, VringPollHandler};
 
 mod handler;
 pub use self::handler::VhostUserHandlerError;
@@ -239,13 +239,13 @@ where
         }
     }
 
-    /// Retrieve the vring epoll handler.
+    /// Retrieve the vring poll handler.
     ///
     /// This is necessary to perform further actions like registering and unregistering some extra
     /// event file descriptors.
-    pub fn get_epoll_handlers(&self) -> Vec<Arc<VringEpollHandler<T>>> {
+    pub fn get_poll_handlers(&self) -> Vec<Arc<VringPollHandler<T>>> {
         // Do not expect poisoned lock.
-        self.handler.lock().unwrap().get_epoll_handlers()
+        self.handler.lock().unwrap().get_poll_handlers()
     }
 }
 
@@ -267,7 +267,7 @@ mod tests {
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();
 
-        let handlers = daemon.get_epoll_handlers();
+        let handlers = daemon.get_poll_handlers();
         assert_eq!(handlers.len(), 2);
 
         let barrier = Arc::new(Barrier::new(2));
@@ -300,7 +300,7 @@ mod tests {
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();
 
-        let handlers = daemon.get_epoll_handlers();
+        let handlers = daemon.get_poll_handlers();
         assert_eq!(handlers.len(), 2);
 
         let barrier = Arc::new(Barrier::new(2));

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -117,7 +117,7 @@ impl VhostUserBackendMut for MockVhostBackend {
 
     fn handle_event(
         &mut self,
-        _device_event: u16,
+        _device_event: usize,
         _evset: EventSet,
         _vrings: &[VringRwLock],
         _thread_id: usize,

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -13,11 +13,10 @@ use vhost::vhost_user::message::{
 };
 use vhost::vhost_user::{Backend, Frontend, Listener, VhostUserFrontend};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
-use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
+use vhost_user_backend::{EventSet, VhostUserBackendMut, VhostUserDaemon, VringRwLock};
 use vm_memory::{
     FileOffset, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap,
 };
-use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::event::{
     new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,
 };


### PR DESCRIPTION
### Summary of the PR

Epoll is linux-specific. So we use mio, which is a cross-platform event notification, to replace Epoll.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ x ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ x ] All added/changed functionality has a corresponding unit/integration
  test.
- [ x ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ x ] Any newly added `unsafe` code is properly documented.
