### PR TITLE
Fix "mismatched lifetime syntaxes" warning

### DIFF
--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -38,10 +38,10 @@ pub trait VringT<M: GuestAddressSpace>:
         Self: Sized;
 
     /// Get an immutable reference to the kick event fd.
-    fn get_ref(&self) -> <Self as VringStateGuard<M>>::G;
+    fn get_ref(&self) -> <Self as VringStateGuard<'_, M>>::G;
 
     /// Get a mutable reference to the kick event fd.
-    fn get_mut(&self) -> <Self as VringStateMutGuard<M>>::G;
+    fn get_mut(&self) -> <Self as VringStateMutGuard<'_, M>>::G;
 
     /// Add an used descriptor into the used queue.
     fn add_used(&self, desc_index: u16, len: u32) -> Result<(), VirtQueError>;


### PR DESCRIPTION
### Summary of the PR

rust 1.89 made the "mismatched lifetime syntaxes" lint to show a warning by default:
https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

Add a placeholder lifetime to `vhost_user_backend::vring::VringStateMutGuard` to be explicit.

