### PR TITLE
vhost_user: don't take ownership of `Listener`

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 ### Changed
 - [[#308](https://github.com/rust-vmm/vhost/pull/308)] Replace Eventfd with EventNotifier/EventConsumer.
+- [[#321](https://github.com/rust-vmm/vhost/pull/321)] Don't take ownership of listener in `VhostUserDaemon::start`.
 
 ### Deprecated
 ### Fixed

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -260,9 +260,9 @@ fn vhost_user_server_with_fn<F: FnOnce(Arc<Mutex<MockVhostBackend>>, Arc<Barrier
     let path1 = path.clone();
     let thread = thread::spawn(move || cb(&path1, barrier2));
 
-    let listener = Listener::new(&path, false).unwrap();
+    let mut listener = Listener::new(&path, false).unwrap();
     barrier.wait();
-    daemon.start(listener).unwrap();
+    daemon.start(&mut listener).unwrap();
     barrier.wait();
 
     server_fn(backend, barrier);

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -7,6 +7,8 @@
   `From<UnixListener>` for `vhost_user::Listener`.
 
 ### Changed
+- [[#321](https://github.com/rust-vmm/vhost/pull/321)] Don't take ownership of listener in `BackendListener`.
+
 ### Deprecated
 ### Fixed
 - [[#304]](https://github.com/rust-vmm/vhost/pull/304) Fix building docs.

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -293,8 +293,8 @@ mod tests {
         P: AsRef<Path>,
         S: VhostUserBackendReqHandler,
     {
-        let listener = Listener::new(&path, true).unwrap();
-        let mut backend_listener = BackendListener::new(listener, backend).unwrap();
+        let mut listener = Listener::new(&path, true).unwrap();
+        let mut backend_listener = BackendListener::new(&mut listener, backend).unwrap();
         let frontend = Frontend::connect(&path, 1).unwrap();
         (frontend, backend_listener.accept().unwrap().unwrap())
     }


### PR DESCRIPTION
### Summary of the PR

The vhost-device devices all call `VhostUserDaemon::serve` in a loop, to handle reconnections.  This is not ideal, because a new listener is created each loop iteration, which means that each time, the old socket is unlinked and a new one is created.  This means that there's a potential race where a frontend attempts to connect to the backend before the new socket is created.

A more robust way to achieve this would be to have the devices create their own listeners, and pass the same one to `VhostUserDaemon::start` on each loop iteration, instead of letting `VhostUserDaemon::serve` create it repeatedly.  This was not previously possible though, because `VhostUserDaemon::start` consumed the listener, even though it didn't need to.

Because it's now possible to call `VhostUserDaemon::start` multiple times with the same socket, I've removed the TODO about handling reconnection.  If the TODO was supposed to capture more than that, I can put it back (ideally with clearer phrasing).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
