### PR TITLE
vhost_user: fix mismatched lifetime warning

### DIFF
--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -128,7 +128,7 @@ impl Frontend {
         }
     }
 
-    fn node(&self) -> MutexGuard<FrontendInternal> {
+    fn node(&self) -> MutexGuard<'_, FrontendInternal> {
         self.node.lock().unwrap()
     }
 


### PR DESCRIPTION
### Summary of the PR 

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> vhost/src/vhost_user/frontend.rs:131:13
    |
131 |     fn node(&self) -> MutexGuard<FrontendInternal> {
    |             ^^^^^     ---------------------------- the same lifetime is hidden here
    |             |
    |             the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
131 |     fn node(&self) -> MutexGuard<'_, FrontendInternal> {
    |                                  +++
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
