### PR TITLE
[RFC] Make Xen and non-Xen worlds compatible

### DIFF
--- a/vhost-user-backend/README.md
+++ b/vhost-user-backend/README.md
@@ -19,7 +19,7 @@ where
     V: VringT<GM<B>> + Clone + Send + Sync + 'static,
     B: Bitmap + 'static,
 {
-    pub fn new(name: String, backend: S, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap<B>>) -> Result<Self>;
+    pub fn new(name: String, backend: S, atomic_mem: GM<B>) -> Result<Self>;
     pub fn start(&mut self, listener: Listener) -> Result<()>;
     pub fn wait(&mut self) -> Result<()>;
     pub fn get_epoll_handlers(&self) -> Vec<Arc<VringEpollHandler<S, V, B>>>;

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -685,7 +685,7 @@ pub mod tests {
             Ok(())
         }
 
-        fn update_memory(&mut self, _atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
+        fn update_memory(&mut self, _atomic_mem: GM) -> Result<()> {
             Ok(())
         }
 

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -13,11 +13,11 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use vhost::vhost_user::{BackendListener, BackendReqHandler, Error as VhostUserError, Listener};
-use vm_memory::mmap::NewBitmap;
-use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
-
 use self::handler::VhostUserHandler;
+use vhost::vhost_user::{BackendListener, BackendReqHandler, Error as VhostUserError, Listener};
+use vhost::MemoryRegion;
+use vm_memory::mmap::NewBitmap;
+use vm_memory::{GuestMemoryAtomic, GuestRegionCollection};
 
 mod backend;
 pub use self::backend::{VhostUserBackend, VhostUserBackendMut};
@@ -43,7 +43,7 @@ pub use self::vring::{
 compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
 
 /// An alias for `GuestMemoryAtomic<GuestMemoryMmap<B>>` to simplify code.
-type GM<B = ()> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
+type GM<B = ()> = GuestMemoryAtomic<GuestRegionCollection<MemoryRegion<B>>>;
 
 #[derive(Debug)]
 /// Errors related to vhost-user daemon.

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -43,7 +43,7 @@ pub use self::vring::{
 compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
 
 /// An alias for `GuestMemoryAtomic<GuestMemoryMmap<B>>` to simplify code.
-type GM<B> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
+type GM<B = ()> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
 
 #[derive(Debug)]
 /// Errors related to vhost-user daemon.
@@ -106,11 +106,7 @@ where
     /// Under the hood, this will start a dedicated thread responsible for listening onto
     /// registered event. Those events can be vring events or custom events from the backend,
     /// but they get to be registered later during the sequence.
-    pub fn new(
-        name: String,
-        backend: T,
-        atomic_mem: GuestMemoryAtomic<GuestMemoryMmap<T::Bitmap>>,
-    ) -> Result<Self> {
+    pub fn new(name: String, backend: T, atomic_mem: GM<T::Bitmap>) -> Result<Self> {
         let handler = Arc::new(Mutex::new(
             VhostUserHandler::new(backend, atomic_mem).map_err(Error::NewVhostUserHandler)?,
         ));

--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -13,8 +13,9 @@ use std::result::Result;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crate::GM;
 use virtio_queue::{Error as VirtQueError, Queue, QueueT};
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{GuestAddress, GuestAddressSpace};
 use vmm_sys_util::event::{EventConsumer, EventNotifier};
 
 /// Trait for objects returned by `VringT::get_ref()`.
@@ -107,7 +108,7 @@ pub trait VringT<M: GuestAddressSpace>:
 ///
 /// This struct maintains all information of a virito queue, and could be used as an `VringT`
 /// object for single-threaded context.
-pub struct VringState<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>> {
+pub struct VringState<M: GuestAddressSpace = GM> {
     queue: Queue,
     kick: Option<EventConsumer>,
     call: Option<EventNotifier>,
@@ -269,7 +270,7 @@ impl<M: GuestAddressSpace> VringState<M> {
 
 /// A `VringState` object protected by Mutex for multi-threading context.
 #[derive(Clone)]
-pub struct VringMutex<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>> {
+pub struct VringMutex<M: GuestAddressSpace = GM> {
     state: Arc<Mutex<VringState<M>>>,
 }
 
@@ -384,7 +385,7 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringMutex<M> {
 
 /// A `VringState` object protected by RwLock for multi-threading context.
 #[derive(Clone)]
-pub struct VringRwLock<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>> {
+pub struct VringRwLock<M: GuestAddressSpace = GM> {
     state: Arc<RwLock<VringState<M>>>,
 }
 

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -90,7 +90,7 @@ impl VhostUserBackendMut for MockVhostBackend {
         Ok(())
     }
 
-    fn update_memory(&mut self, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
+    fn update_memory(&mut self, atomic_mem: GM) -> Result<()> {
         let mem = atomic_mem.memory();
         let region = mem.find_region(GuestAddress(0x100000)).unwrap();
         assert_eq!(region.size(), 0x100000);

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -125,16 +125,7 @@ impl VhostUserMemoryRegionInfo {
     /// Creates VhostUserSingleMemoryRegion from Self.
     #[cfg(feature = "vhost-user")]
     pub fn to_single_region(&self) -> VhostUserSingleMemoryRegion {
-        VhostUserSingleMemoryRegion::new(
-            self.guest_phys_addr,
-            self.memory_size,
-            self.userspace_addr,
-            self.mmap_offset,
-            #[cfg(feature = "xen")]
-            self.xen_mmap_flags,
-            #[cfg(feature = "xen")]
-            self.xen_mmap_data,
-        )
+        self.into()
     }
 }
 

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -86,6 +86,22 @@ pub struct VhostUserMemoryRegionInfo {
     pub xen_mmap_data: u32,
 }
 
+#[cfg(feature = "vhost-user")]
+impl From<&VhostUserMemoryRegionInfo> for VhostUserMemoryRegion {
+    fn from(region: &VhostUserMemoryRegionInfo) -> Self {
+        VhostUserMemoryRegion {
+            guest_phys_addr: region.guest_phys_addr,
+            memory_size: region.memory_size,
+            user_addr: region.userspace_addr,
+            mmap_offset: region.mmap_offset,
+            #[cfg(feature = "xen")]
+            xen_mmap_flags: region.xen_mmap_flags,
+            #[cfg(feature = "xen")]
+            xen_mmap_data: region.xen_mmap_data,
+        }
+    }
+}
+
 impl VhostUserMemoryRegionInfo {
     /// Creates Self from GuestRegionMmap.
     pub fn from_guest_region<B: Bitmap>(region: &GuestRegionMmap<B>) -> Result<Self> {
@@ -104,28 +120,6 @@ impl VhostUserMemoryRegionInfo {
             #[cfg(feature = "xen")]
             xen_mmap_data: region.xen_mmap_data(),
         })
-    }
-
-    /// Creates VhostUserMemoryRegion from Self.
-    #[cfg(feature = "vhost-user")]
-    pub fn to_region(&self) -> VhostUserMemoryRegion {
-        #[cfg(not(feature = "xen"))]
-        return VhostUserMemoryRegion::new(
-            self.guest_phys_addr,
-            self.memory_size,
-            self.userspace_addr,
-            self.mmap_offset,
-        );
-
-        #[cfg(feature = "xen")]
-        VhostUserMemoryRegion::with_xen(
-            self.guest_phys_addr,
-            self.memory_size,
-            self.userspace_addr,
-            self.mmap_offset,
-            self.xen_mmap_flags,
-            self.xen_mmap_data,
-        )
     }
 
     /// Creates VhostUserSingleMemoryRegion from Self.

--- a/vhost/src/lib.rs
+++ b/vhost/src/lib.rs
@@ -30,15 +30,23 @@
 //! that shares its virtqueues. Backend is the consumer of the virtqueues. Frontend and backend can be
 //! either a client (i.e. connecting) or server (listening) in the socket communication.
 
-#![deny(missing_docs)]
-
 #[cfg_attr(feature = "vhost-user", macro_use)]
 extern crate bitflags;
 #[cfg_attr(feature = "vhost-kern", macro_use)]
 extern crate vmm_sys_util;
 
 mod backend;
+
+use std::ops::Deref;
+
 pub use backend::*;
+use vm_memory::bitmap::{Bitmap, BS};
+#[cfg(feature = "xen")]
+use vm_memory::GuestRegionXen;
+use vm_memory::{
+    GuestAddress, GuestMemoryRegion, GuestMemoryRegionBytes, GuestRegionMmap, GuestUsize,
+    MemoryRegionAddress, VolatileSlice,
+};
 
 #[cfg(feature = "vhost-net")]
 pub mod net;
@@ -127,6 +135,75 @@ impl std::convert::From<vhost_user::Error> for Error {
 
 /// Result of vhost operations
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub enum MemoryRegion<B> {
+    Unix(GuestRegionMmap<B>),
+    #[cfg(feature = "xen")]
+    Xen(GuestRegionXen<B>),
+}
+
+impl<B: Bitmap> MemoryRegion<B> {
+    pub fn bitmap(&self) -> &B {
+        match self {
+            MemoryRegion::Unix(r) => (*r).deref().bitmap(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.bitmap(),
+        }
+    }
+}
+
+impl<B: Bitmap> GuestMemoryRegion for MemoryRegion<B> {
+    type B = B;
+
+    fn len(&self) -> GuestUsize {
+        match self {
+            MemoryRegion::Unix(r) => r.len(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.len(),
+        }
+    }
+
+    fn start_addr(&self) -> GuestAddress {
+        match self {
+            MemoryRegion::Unix(r) => r.start_addr(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.start_addr(),
+        }
+    }
+
+    fn bitmap(&self) -> BS<'_, Self::B> {
+        match self {
+            MemoryRegion::Unix(r) => r.bitmap(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => <GuestRegionXen<B> as GuestMemoryRegion>::bitmap(r),
+        }
+    }
+
+    fn get_host_address(
+        &self,
+        addr: MemoryRegionAddress,
+    ) -> vm_memory::guest_memory::Result<*mut u8> {
+        match self {
+            MemoryRegion::Unix(r) => r.get_host_address(addr),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.get_host_address(addr),
+        }
+    }
+
+    fn get_slice(
+        &self,
+        offset: MemoryRegionAddress,
+        count: usize,
+    ) -> vm_memory::guest_memory::Result<VolatileSlice<BS<Self::B>>> {
+        match self {
+            MemoryRegion::Unix(r) => r.get_slice(offset, count),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.get_slice(offset, count),
+        }
+    }
+}
+
+impl<B: Bitmap> GuestMemoryRegionBytes for MemoryRegion<B> {}
 
 #[cfg(test)]
 mod tests {

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -223,7 +223,7 @@ impl VhostBackend for Frontend {
                 return error_code(VhostUserError::InvalidParam);
             }
 
-            ctx.append(&region.to_region(), region.mmap_handle);
+            ctx.append(&region.into(), region.mmap_handle);
         }
 
         let mut node = self.node();

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -23,7 +23,7 @@ use vm_memory::{mmap::NewBitmap, ByteValued, Error as MmapError, FileOffset, Mma
 use vm_memory::{GuestAddress, MmapRange, MmapXenFlags};
 
 use super::{enum_value, Error, Result};
-use crate::VringConfigData;
+use crate::{VhostUserMemoryRegionInfo, VringConfigData};
 
 /*
 TODO: Consider deprecating this. We don't actually have any preallocated buffers except in tests,
@@ -639,43 +639,12 @@ impl Deref for VhostUserSingleMemoryRegion {
     }
 }
 
-#[cfg(not(feature = "xen"))]
-impl VhostUserSingleMemoryRegion {
-    /// Create a new instance.
-    pub fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
+#[cfg(feature = "vhost-user")]
+impl From<&VhostUserMemoryRegionInfo> for VhostUserSingleMemoryRegion {
+    fn from(value: &VhostUserMemoryRegionInfo) -> Self {
         VhostUserSingleMemoryRegion {
             padding: 0,
-            region: VhostUserMemoryRegion::new(
-                guest_phys_addr,
-                memory_size,
-                user_addr,
-                mmap_offset,
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "xen")]
-impl VhostUserSingleMemoryRegion {
-    /// Create a new instance.
-    pub fn new(
-        guest_phys_addr: u64,
-        memory_size: u64,
-        user_addr: u64,
-        mmap_offset: u64,
-        xen_mmap_flags: u32,
-        xen_mmap_data: u32,
-    ) -> Self {
-        VhostUserSingleMemoryRegion {
-            padding: 0,
-            region: VhostUserMemoryRegion::with_xen(
-                guest_phys_addr,
-                memory_size,
-                user_addr,
-                mmap_offset,
-                xen_mmap_flags,
-                xen_mmap_data,
-            ),
+            region: value.into(),
         }
     }
 }


### PR DESCRIPTION
### Summary of the PR

[ based on https://github.com/rust-vmm/vm-memory/pull/317 ]

Fix up the xen feature such that compiling with `--feature xen` allows serving both xen and non-xen VMMs. Whether or not we are dealing with a xen frontend is determined by inspecting the control messages (if the xen fields are around, then construct `GuestRegionXen', otherwise just use plain old `GuestRegionMmap` (unix)).

The first 4 commits are just cleanups that could probably be merged as is, but I'm not too sure whether they mess up the crates' API or not.

As for how to test this, you'll need a `[patch.crates-io]` for vm-memory pointed to a checkout of the above PR, with vm-memory's Cargo.toml fixed up to pretend to be version 0.16.2. 

I also had a quick go at compile testing this against vhost-device, but vmm-sys-util incompatibilities were the only errors I got (apart from some needed changes from GuestMemoryMmap to GuestMemoryCollection).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
