### PR TITLE
vhost-user-backend: Allow AtomicBitmap

### DIFF
--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- Support for using AtomicBitmap (from vm_memory)
+  when migration is not needed.
+
 ### Changed
 ### Deprecated
 ### Fixed

--- a/vhost-user-backend/src/bitmap.rs
+++ b/vhost-user-backend/src/bitmap.rs
@@ -7,7 +7,7 @@ use std::os::fd::{AsRawFd, BorrowedFd};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
 use std::{io, ptr};
-use vm_memory::bitmap::{Bitmap, BitmapSlice, WithBitmapSlice};
+use vm_memory::bitmap::{AtomicBitmap, Bitmap, BitmapSlice, WithBitmapSlice};
 use vm_memory::mmap::NewBitmap;
 use vm_memory::{Address, GuestMemoryRegion};
 
@@ -44,7 +44,22 @@ impl BitmapReplace for () {
     }
 }
 
+impl BitmapReplace for AtomicBitmap {
+    type InnerBitmap = ();
+
+    // this implementation must not be used if the backend sets `VHOST_USER_PROTOCOL_F_LOG_SHMFD`
+    fn replace(&self, _bitmap: ()) {
+        panic!("AtomicBitmap must not be used if VHOST_USER_PROTOCOL_F_LOG_SHMFD is set");
+    }
+}
+
 impl MemRegionBitmap for () {
+    fn new<R: GuestMemoryRegion>(_region: &R, _logmem: Arc<MmapLogReg>) -> io::Result<Self> {
+        Err(io::Error::from(io::ErrorKind::Unsupported))
+    }
+}
+
+impl MemRegionBitmap for AtomicBitmap {
     fn new<R: GuestMemoryRegion>(_region: &R, _logmem: Arc<MmapLogReg>) -> io::Result<Self> {
         Err(io::Error::from(io::ErrorKind::Unsupported))
     }

--- a/vhost-user-backend/tests/atomic-bitmap-compiles.rs
+++ b/vhost-user-backend/tests/atomic-bitmap-compiles.rs
@@ -1,0 +1,15 @@
+//! Check that [`AtomicBitmap`] implements [`BitmapReplace`]
+//! and [`MemRegionBitmap`] so one can use it for vhost-user
+//! backends that do not support migration.
+
+use vhost_user_backend::bitmap::{BitmapReplace, MemRegionBitmap};
+use vm_memory::bitmap::AtomicBitmap;
+
+fn check1<T: MemRegionBitmap>() {}
+
+fn check2<T: BitmapReplace>() {}
+
+fn main() {
+    check1::<AtomicBitmap>();
+    check2::<AtomicBitmap>();
+}


### PR DESCRIPTION
### Summary of the PR

https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7971 changes the block layer to require that AtomicBitmap is used.  This breaks the vhost-user server.  Since this server is only for testing, making the whole block layer generic is undesirable.

Allow AtomicBitmap to be used when migration is not needed.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
