### PR TITLE
fix: remove default features for uuid crate

### DIFF
--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -30,7 +30,7 @@ postcopy = []
 [dependencies]
 bitflags = "2.4"
 libc = "0.2.39"
-uuid = { version = "1.11.0", features=["v4", "fast-rng"] }
+uuid = { version = "1.11.0", default-features = false, features=["v4", "fast-rng"] }
 
 vmm-sys-util = { workspace = true }
 vm-memory = { workspace = true, features=["backend-mmap"] }


### PR DESCRIPTION
### Summary of the PR

`uuid` crate default features pull `wasm-bindgen` and `js-sys` crates as dependencies but none of them are required in this crate. Additionally this unnecessarily adds these dependencies to all users of the crate. Fix this by disabling default features for `uuid` crate.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
