### PR TITLE
vhost-user: validate AF_UNIX SOCK_STREAM socket file descriptor

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - [[#355]](https://github.com/rust-vmm/vhost/pull/355) Add socket-cloning helpers for backend request handlers.
+- [[#360]](https://github.com/rust-vmm/vhost/pull/360) Validate AF_UNIX SOCK_STREAM socket file descriptors and 
+  add Error::InvalidSocketFd, Error::NotUnixSocket and Error::NotStreamSocket.
 ### Changed
 ### Deprecated
 ### Fixed

--- a/vhost/src/vhost_user/backend_req_handler.rs
+++ b/vhost/src/vhost_user/backend_req_handler.rs
@@ -3,6 +3,7 @@
 
 use std::fs::File;
 use std::mem;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::slice;
@@ -852,9 +853,14 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
 
     fn set_backend_req_fd(&mut self, files: Option<Vec<File>>) -> Result<()> {
         let file = take_single_file(files).ok_or(Error::InvalidMessage)?;
-        // SAFETY: Safe because we have ownership of the files that were
-        // checked when received. We have to trust that they are Unix sockets
-        // since we have no way to check this. If not, it will fail later.
+        // Validate that the received file descriptor is an AF_UNIX SOCK_STREAM
+        // socket as required by the vhost-user backend request channel.
+        validate_unix_stream_socket_fd(file.as_fd())?;
+        // SAFETY:
+        // Ownership of the file descriptor is transferred from `File` via
+        // `into_raw_fd()`, ensuring this code is the sole owner of the FD.
+        // The descriptor has been validated to be an AF_UNIX SOCK_STREAM socket,
+        // so it is safe to construct a `UnixStream` from it.
         let sock = unsafe { UnixStream::from_raw_fd(file.into_raw_fd()) };
         let backend = Backend::from_stream(sock);
         self.backend.set_backend_req_fd(backend);
@@ -863,9 +869,14 @@ impl<S: VhostUserBackendReqHandler> BackendReqHandler<S> {
 
     fn set_gpu_socket(&mut self, files: Option<Vec<File>>) -> Result<()> {
         let file = take_single_file(files).ok_or(Error::InvalidMessage)?;
-        // SAFETY: Safe because we have ownership of the files that were
-        // checked when received. We have to trust that they are Unix sockets
-        // since we have no way to check this. If not, it will fail later.
+        // Validate that the received file descriptor is an AF_UNIX SOCK_STREAM
+        // socket as required by the vhost-user GPU channel.
+        validate_unix_stream_socket_fd(file.as_fd())?;
+        // SAFETY:
+        // Ownership of the file descriptor is transferred from `File` via
+        // `into_raw_fd()`, ensuring this code is the sole owner of the FD.
+        // The descriptor has been validated to be an AF_UNIX SOCK_STREAM socket,
+        // so it is safe to construct a `UnixStream` from it.
         let sock = unsafe { UnixStream::from_raw_fd(file.into_raw_fd()) };
         let gpu_backend = GpuBackend::from_stream(sock);
         self.backend.set_gpu_socket(gpu_backend)
@@ -1036,8 +1047,52 @@ impl<S: VhostUserBackendReqHandler> AsRawFd for BackendReqHandler<S> {
     }
 }
 
+// Retrieve a SOL_SOCKET socket option value using `getsockopt`.
+fn get_socket_opt(fd: BorrowedFd<'_>, opt: libc::c_int) -> std::io::Result<libc::c_int> {
+    let mut value: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+
+    // SAFETY:
+    // - `value` and `len` point to valid writable memory.
+    // - `len` is initialized to `size_of::<libc::c_int>()`, matching the size
+    //   of `value`, so `getsockopt()` will not write past the end of `value`.
+    // - `fd.as_raw_fd()` is valid because `BorrowedFd` guarantees a live file
+    //   descriptor for the duration of the call.
+    let rc = unsafe {
+        libc::getsockopt(
+            fd.as_raw_fd(),
+            libc::SOL_SOCKET,
+            opt,
+            std::ptr::addr_of_mut!(value).cast::<libc::c_void>(),
+            std::ptr::addr_of_mut!(len),
+        )
+    };
+
+    if rc == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(value)
+    }
+}
+
+// Validate that the given file descriptor is an AF_UNIX SOCK_STREAM socket.
+fn validate_unix_stream_socket_fd(fd: BorrowedFd<'_>) -> Result<()> {
+    let domain = get_socket_opt(fd, libc::SO_DOMAIN).map_err(Error::InvalidSocketFd)?;
+    if domain != libc::AF_UNIX {
+        return Err(Error::NotUnixSocket);
+    }
+
+    let sock_type = get_socket_opt(fd, libc::SO_TYPE).map_err(Error::InvalidSocketFd)?;
+    if sock_type != libc::SOCK_STREAM {
+        return Err(Error::NotStreamSocket);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::net::TcpListener;
     use std::os::unix::io::AsRawFd;
 
     use super::*;
@@ -1158,5 +1213,24 @@ mod tests {
             let _ = frontend_endpoint.send_message(&hdr, &VhostUserEmpty, None);
         });
         assert!(handler.handle_request().is_err());
+    }
+
+    #[test]
+    fn test_validate_unix_stream_socket_fd() {
+        // Valid AF_UNIX SOCK_STREAM socket
+        let (sock1, _sock2) = UnixStream::pair().unwrap();
+        assert!(validate_unix_stream_socket_fd(sock1.as_fd()).is_ok());
+
+        // AF_INET socket (wrong domain)
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        assert!(validate_unix_stream_socket_fd(listener.as_fd()).is_err());
+
+        // Non-socket file descriptor
+        let file = File::open("/dev/null").unwrap();
+        assert!(validate_unix_stream_socket_fd(file.as_fd()).is_err());
+
+        // AF_UNIX but SOCK_DGRAM (wrong type)
+        let dgram = std::os::unix::net::UnixDatagram::unbound().unwrap();
+        assert!(validate_unix_stream_socket_fd(dgram.as_fd()).is_err());
     }
 }

--- a/vhost/src/vhost_user/mod.rs
+++ b/vhost/src/vhost_user/mod.rs
@@ -68,6 +68,12 @@ pub enum Error {
     InactiveOperation(VhostUserProtocolFeatures),
     /// Invalid message format, flag or content.
     InvalidMessage,
+    /// Invalid `AF_UNIX SOCK_STREAM` socket file descriptor.
+    InvalidSocketFd(std::io::Error),
+    /// Socket is not `AF_UNIX`
+    NotUnixSocket,
+    /// Socket is not `SOCK_STREAM`
+    NotStreamSocket,
     /// Only part of a message have been sent or received successfully
     PartialMessage,
     /// The peer disconnected from the socket.
@@ -110,6 +116,9 @@ impl std::fmt::Display for Error {
                 write!(f, "inactive protocol operation: {}", bits.bits())
             }
             Error::InvalidMessage => write!(f, "invalid message"),
+            Error::InvalidSocketFd(e) => write!(f, "invalid AF_UNIX SOCK_STREAM socket fd: {e}"),
+            Error::NotUnixSocket => write!(f, "socket is not AF_UNIX"),
+            Error::NotStreamSocket => write!(f, "socket is not SOCK_STREAM"),
             Error::PartialMessage => write!(f, "partial message"),
             Error::Disconnected => write!(f, "peer disconnected"),
             Error::OversizedMsg => write!(f, "oversized message"),
@@ -157,6 +166,9 @@ impl Error {
             Error::InvalidParam | Error::InvalidOperation(_) => false,
             Error::InactiveFeature(_) | Error::InactiveOperation(_) => false,
             Error::InvalidMessage | Error::IncorrectFds | Error::OversizedMsg => false,
+            Error::InvalidSocketFd(_) => false,
+            Error::NotUnixSocket => false,
+            Error::NotStreamSocket => false,
             Error::SocketError(_) | Error::SocketConnect(_) => false,
             Error::FeatureMismatch => false,
             Error::ReqHandlerError(_) => false,
@@ -268,6 +280,7 @@ mod tests {
     use message::VhostUserSharedMsg;
     use std::fs::File;
     use std::os::unix::io::AsRawFd;
+    use std::os::unix::net::UnixStream;
     use std::path::{Path, PathBuf};
     use std::sync::{Arc, Barrier, Mutex};
     use std::thread;
@@ -490,6 +503,7 @@ mod tests {
         assert_eq!(num, 2);
 
         let eventfd = vmm_sys_util::eventfd::EventFd::new(0).unwrap();
+        let (tx, _) = UnixStream::pair().unwrap();
         let mem = [VhostUserMemoryRegionInfo::new(
             0,
             0x10_0000,
@@ -510,7 +524,7 @@ mod tests {
         assert_eq!(offset, 0x100);
         assert_eq!(&reply_payload, &[0xa5; 4]);
 
-        frontend.set_backend_request_fd(&eventfd).unwrap();
+        frontend.set_backend_request_fd(&tx).unwrap();
         frontend.set_vring_enable(0, true).unwrap();
 
         frontend


### PR DESCRIPTION
Validate that the file descriptor received through SET_BACKEND_REQ_FD is an AF_UNIX SOCK_STREAM socket before constructing UnixStream from it.

### Summary of the PR

The vhost-user backend currently assumes that the file descriptor received
through `SET_BACKEND_REQ_FD` is a Unix domain stream socket and constructs a
`UnixStream` from it without validation.

This change validates the received file descriptor before it is used by
checking its socket properties via `getsockopt()`. The validation ensures that
the descriptor corresponds to an `AF_UNIX` `SOCK_STREAM` socket, which is the
expected type for the backend request channel according to the vhost-user
protocol.

The PR also adds tests covering valid and invalid file descriptors.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
