### PR TITLE
Update vm-memory dependency to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ members = [
 
 [workspace.dependencies]
 virtio-bindings = "0.2.6"
-virtio-queue = "0.17.0"
-vm-memory = "=0.17.1"
+virtio-queue = "0.18.0"
+vm-memory = "0.18.0"
 vmm-sys-util = "0.15.0"

--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 - [[#355]](https://github.com/rust-vmm/vhost/pull/355) Add an explicit shutdown handle for active daemon connections.
 ### Changed
+- [[#364]](https://github.com/rust-vmm/vhost/pull/364) Updated vm-memory to 0.18.0
+
 ### Deprecated
 ### Fixed
 

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -30,7 +30,9 @@ use vhost::vhost_user::{
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Error as VirtQueError, QueueT};
 use vm_memory::mmap::NewBitmap;
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
+use vm_memory::{
+    GuestAddress, GuestAddressSpace, GuestMemoryBackend, GuestMemoryMmap, GuestRegionMmap,
+};
 use vmm_sys_util::epoll::EventSet;
 
 use super::backend::VhostUserBackend;

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -15,7 +15,8 @@ use vhost::vhost_user::{Backend, Frontend, Listener, VhostUserFrontend};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
 use vm_memory::{
-    FileOffset, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap,
+    FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
+    GuestMemoryMmap,
 };
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::event::{

--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[#360]](https://github.com/rust-vmm/vhost/pull/360) Validate AF_UNIX SOCK_STREAM socket file descriptors and 
   add Error::InvalidSocketFd, Error::NotUnixSocket and Error::NotStreamSocket.
 ### Changed
+- [[#364]](https://github.com/rust-vmm/vhost/pull/364) Updated vm-memory to 0.18.0
 ### Deprecated
 ### Fixed
 

--- a/vhost/src/vhost_kern/mod.rs
+++ b/vhost/src/vhost_kern/mod.rs
@@ -16,7 +16,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 
 use libc::{c_void, ssize_t, write};
 
-use vm_memory::{Address, GuestAddress, GuestAddressSpace, GuestMemory, GuestUsize};
+use vm_memory::{Address, GuestAddress, GuestAddressSpace, GuestMemoryBackend, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref};
 
@@ -38,9 +38,9 @@ pub mod vsock;
 
 /// Helper trait to signify `GuestAddressSpace`s that are physical, which is required for
 /// vhost_kern.
-pub trait PhysicalGuestAddressSpace: GuestAddressSpace<M: GuestMemory> {}
+pub trait PhysicalGuestAddressSpace: GuestAddressSpace<M: GuestMemoryBackend> {}
 
-impl<AS: GuestAddressSpace> PhysicalGuestAddressSpace for AS where AS::M: GuestMemory {}
+impl<AS: GuestAddressSpace> PhysicalGuestAddressSpace for AS where AS::M: GuestMemoryBackend {}
 
 #[inline]
 fn ioctl_result<T>(rc: i32, res: T) -> Result<T> {

--- a/vhost/src/vhost_kern/mod.rs
+++ b/vhost/src/vhost_kern/mod.rs
@@ -36,6 +36,12 @@ pub mod vdpa;
 #[cfg(feature = "vhost-vsock")]
 pub mod vsock;
 
+/// Helper trait to signify `GuestAddressSpace`s that are physical, which is required for
+/// vhost_kern.
+pub trait PhysicalGuestAddressSpace: GuestAddressSpace<M: GuestMemory> {}
+
+impl<AS: GuestAddressSpace> PhysicalGuestAddressSpace for AS where AS::M: GuestMemory {}
+
 #[inline]
 fn ioctl_result<T>(rc: i32, res: T) -> Result<T> {
     if rc < 0 {
@@ -57,7 +63,7 @@ fn io_result<T>(rc: isize, res: T) -> Result<T> {
 /// Represent an in-kernel vhost device backend.
 pub trait VhostKernBackend: AsRawFd {
     /// Associated type to access guest memory.
-    type AS: GuestAddressSpace;
+    type AS: PhysicalGuestAddressSpace;
 
     /// Get the object to access the guest's memory.
     fn mem(&self) -> &Self::AS;
@@ -439,7 +445,7 @@ impl VhostIotlbMsgParser for vhost_msg_v2 {
 impl VringConfigData {
     /// Convert the config (guest address space) into vhost_vring_addr
     /// (host address space).
-    pub fn to_vhost_vring_addr<AS: GuestAddressSpace>(
+    pub fn to_vhost_vring_addr<AS: PhysicalGuestAddressSpace>(
         &self,
         queue_index: usize,
         mem: &AS,

--- a/vhost/src/vhost_kern/net.rs
+++ b/vhost/src/vhost_kern/net.rs
@@ -68,7 +68,7 @@ impl<AS: GuestAddressSpace> AsRawFd for Net<AS> {
 
 #[cfg(test)]
 mod tests {
-    use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;

--- a/vhost/src/vhost_kern/net.rs
+++ b/vhost/src/vhost_kern/net.rs
@@ -7,11 +7,12 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use vm_memory::GuestAddressSpace;
 use vmm_sys_util::ioctl::ioctl_with_ref;
 
 use super::vhost_binding::*;
-use super::{ioctl_result, Error, Result, VhostKernBackend};
+use super::{
+    ioctl_result, Error, PhysicalGuestAddressSpace as GuestAddressSpace, Result, VhostKernBackend,
+};
 
 use crate::net::*;
 

--- a/vhost/src/vhost_kern/vdpa.rs
+++ b/vhost/src/vhost_kern/vdpa.rs
@@ -349,7 +349,7 @@ mod tests {
     const VHOST_VDPA_PATH: &str = "/dev/vhost-vdpa-0";
 
     use std::alloc::{alloc, dealloc, Layout};
-    use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;

--- a/vhost/src/vhost_kern/vdpa.rs
+++ b/vhost/src/vhost_kern/vdpa.rs
@@ -9,13 +9,15 @@ use std::os::raw::{c_uchar, c_uint};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use vm_memory::GuestAddressSpace;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::fam::*;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref};
 
 use super::vhost_binding::*;
-use super::{ioctl_result, Error, Result, VhostKernBackend, VhostKernFeatures};
+use super::{
+    ioctl_result, Error, PhysicalGuestAddressSpace as GuestAddressSpace, Result, VhostKernBackend,
+    VhostKernFeatures,
+};
 use crate::vdpa::*;
 use crate::{VhostAccess, VhostIotlbBackend, VhostIotlbMsg, VhostIotlbType, VringConfigData};
 

--- a/vhost/src/vhost_kern/vsock.rs
+++ b/vhost/src/vhost_kern/vsock.rs
@@ -84,7 +84,7 @@ impl<AS: GuestAddressSpace> AsRawFd for Vsock<AS> {
 
 #[cfg(test)]
 mod tests {
-    use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;

--- a/vhost/src/vhost_kern/vsock.rs
+++ b/vhost/src/vhost_kern/vsock.rs
@@ -11,11 +11,12 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use vm_memory::GuestAddressSpace;
 use vmm_sys_util::ioctl::ioctl_with_ref;
 
 use super::vhost_binding::{VHOST_VSOCK_SET_GUEST_CID, VHOST_VSOCK_SET_RUNNING};
-use super::{ioctl_result, Error, Result, VhostKernBackend};
+use super::{
+    ioctl_result, Error, PhysicalGuestAddressSpace as GuestAddressSpace, Result, VhostKernBackend,
+};
 use crate::vsock::VhostVsock;
 
 const VHOST_PATH: &str = "/dev/vhost-vsock";

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -1478,6 +1478,8 @@ mod tests {
         msg.flags |= 0x80000000;
         assert!(!msg.is_valid());
         msg.flags &= !0x80000000;
+
+        assert!(msg.is_valid());
     }
 
     #[test]


### PR DESCRIPTION
### Summary of the PR

This PR updates the vm-memory dependency to 0.18.

It takes the changes from https://github.com/rust-vmm/vhost/pull/348 and bumps `virtio-queue` now that it got released, in order to unblock integration.

~If it passes CI I will squash and undraft.~

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
