### PR TITLE
vhost: vhost_user: message: fix SHMEM feature bit position

### DIFF
--- a/vhost/CHANGELOG.md
+++ b/vhost/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [[#364]](https://github.com/rust-vmm/vhost/pull/364) Updated vm-memory to 0.18.0
 ### Deprecated
 ### Fixed
+- [[#367]](https://github.com/rust-vmm/vhost/pull/367) Fix `SHMEM` protocol feature bit position (bit 21 → bit 22)
+  to align with the vhost-user spec, and add missing `GPA_ADDRESSES` at bit 21.
 
 ## v0.16.0
 

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -442,9 +442,12 @@ bitflags! {
         const DEVICE_STATE = 0x0008_0000;
         /// Support suspend in-flight I/O requests and record them
         const GET_VRING_BASE_INFLIGHT = 0x0010_0000;
+        /// Use Guest Physical Addresses instead of userspace addresses in memory
+        /// region messages (SET_MEM_TABLE, ADD_MEM_REG, etc.).
+        const GPA_ADDRESSES = 0x0020_0000;
         /// Allow the backend to request file descriptors be mapped into virtio shared memory
         /// regions.
-        const SHMEM = 0x0020_0000;
+        const SHMEM = 0x0040_0000;
     }
 }
 


### PR DESCRIPTION
The SHMEM protocol feature bit was placed at bit 21 (0x0020_0000), but the vhost-user spec defines VHOST_USER_PROTOCOL_F_SHMEM_MAP = 22 (0x0040_0000). Bit 21 is assigned to VHOST_USER_PROTOCOL_F_GPA_ADDRESSES, which was added to the spec in [1].

The mismatch happened because the GPA_ADDRESSES feature was developed concurrently with SHMEM and merged into the QEMU spec around the same time, but the crate was not updated to reflect the final bit assignment.

Fix by shifting SHMEM to bit 22 and adding the missing GPA_ADDRESSES definition at bit 21, aligning with the official vhost-user protocol specification.

[1] - https://gitlab.com/qemu-project/qemu/-/commit/be51b7177c

### Summary of the PR

The SHMEM protocol feature bit is incorrectly placed at bit 21 (0x0020\_0000), which collides with VHOST_USER_PROTOCOL_F_GPA_ADDRESSES (bit 21) in the vhost-user spec. The spec defines VHOST_USER_PROTOCOL_F_SHMEM_MAP = 22 (0x0040\_0000).
This causes backends advertising SHMEM support to unintentionally claim GPA\_ADDRESSES support, which may lead frontends (e.g., QEMU) to send Guest Physical Addresses instead of userspace addresses in memory region messages.
This PR shifts SHMEM to its correct position (bit 22) and adds the missing GPA\_ADDRESSES definition at bit 21.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
