### PR TITLE
Fix docs.rs builds

### DIFF
--- a/vhost-user-backend/Cargo.toml
+++ b/vhost-user-backend/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args  = ['--cfg RUSTDOC_disable_feature_compat_errors']
+rustc-args = ["--cfg", "RUSTDOC_disable_feature_compat_errors"]
 
 [features]
 xen = ["vm-memory/xen", "vhost/xen"]

--- a/vhost-user-backend/build.rs
+++ b/vhost-user-backend/build.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=DOCS_RS");
+    if std::env::var("DOCS_RS").is_ok() {
+        println!("cargo::rustc-cfg=RUSTDOC_disable_feature_compat_errors");
+    }
+}

--- a/vhost/Cargo.toml
+++ b/vhost/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args  = ['--cfg RUSTDOC_disable_feature_compat_errors']
+rustc-args = ["--cfg", "RUSTDOC_disable_feature_compat_errors"]
 
 [features]
 default = []

--- a/vhost/build.rs
+++ b/vhost/build.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=DOCS_RS");
+    if std::env::var("DOCS_RS").is_ok() {
+        println!("cargo::rustc-cfg=RUSTDOC_disable_feature_compat_errors");
+    }
+}


### PR DESCRIPTION
docs.rs builds are failing: <https://docs.rs/crate/vhost-user-backend/0.23.0>

Because PR https://github.com/rust-vmm/vhost/pull/326 did not use the proper `rustc-flags` value for docs.rs builds.

Tested with <https://github.com/syphar/cargo-docs-rs> :

```shell
cargo +nightly docs-rs -p vhost
cargo +nightly docs-rs -p vhost-user-backend
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
