### PR TITLE
vhost-user-backend: log set_vring_num range error

### DIFF
--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -377,6 +377,10 @@ where
             .ok_or(VhostUserError::InvalidParam)?;
 
         if num == 0 || num as usize > self.max_queue_size {
+            log::error!(
+                "vring {index} requested queue size {num} out of range (1-{})",
+                self.max_queue_size
+            );
             return Err(VhostUserError::InvalidParam);
         }
         vring.set_queue_size(num as u16);


### PR DESCRIPTION
### Summary of the PR

This error seems easy to trigger and hard to debug, e.g. vhost-device-gpu's queue size is currently 1024, but crosvm defaults to requesting 32768. The resulting log was really unhelpful:

```
[DEBUG vhost_device_gpu::device] Num queues called
[ERROR vhost_device_gpu] Fatal error: failed to handle request: invalid parameters
```

Make it obvious with an extra message:

```
[ERROR vhost_user_backend::handler] vring 0 requested queue size 32768 out of range (1-1024)
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
  - not really testable functionality..
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
  - is this worth a changelog entry?
- [x] Any newly added `unsafe` code is properly documented.
  - none