### PR TITLE
vhost-user-backend: notify the backend when a vring starts

### DIFF
--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -84,6 +84,23 @@ pub trait VhostUserBackend: Send + Sync {
         Ok(())
     }
 
+    /// Called when a vring becomes both ready and enabled, before any kick is
+    /// delivered on it.
+    ///
+    /// A backend is otherwise only handed a vring from `handle_event`, which
+    /// runs in response to the driver ringing the doorbell. A queue the driver
+    /// has no reason to kick -- a receive queue whose buffers were posted once
+    /// at startup, for example -- is therefore never seen by the backend at
+    /// all. This hook gives a backend one chance to inspect such a queue when
+    /// it is brought up, which is where reconnect reconciliation and inflight
+    /// I/O resubmission belong.
+    ///
+    /// A default implementation is provided as we cannot expect all backends to
+    /// implement this function.
+    fn vring_started(&self, _index: u32, _vring: &Self::Vring) -> Result<()> {
+        Ok(())
+    }
+
     /// Update guest memory regions.
     fn update_memory(&self, mem: GM<Self::Bitmap>) -> Result<()>;
 
@@ -234,6 +251,23 @@ pub trait VhostUserBackendMut: Send + Sync {
         Ok(())
     }
 
+    /// Called when a vring becomes both ready and enabled, before any kick is
+    /// delivered on it.
+    ///
+    /// A backend is otherwise only handed a vring from `handle_event`, which
+    /// runs in response to the driver ringing the doorbell. A queue the driver
+    /// has no reason to kick -- a receive queue whose buffers were posted once
+    /// at startup, for example -- is therefore never seen by the backend at
+    /// all. This hook gives a backend one chance to inspect such a queue when
+    /// it is brought up, which is where reconnect reconciliation and inflight
+    /// I/O resubmission belong.
+    ///
+    /// A default implementation is provided as we cannot expect all backends to
+    /// implement this function.
+    fn vring_started(&mut self, _index: u32, _vring: &Self::Vring) -> Result<()> {
+        Ok(())
+    }
+
     /// Update guest memory regions.
     fn update_memory(&mut self, mem: GM<Self::Bitmap>) -> Result<()>;
 
@@ -378,6 +412,10 @@ impl<T: VhostUserBackend> VhostUserBackend for Arc<T> {
         self.deref().set_config(offset, buf)
     }
 
+    fn vring_started(&self, index: u32, vring: &Self::Vring) -> Result<()> {
+        self.deref().vring_started(index, vring)
+    }
+
     fn update_memory(&self, mem: GM<Self::Bitmap>) -> Result<()> {
         self.deref().update_memory(mem)
     }
@@ -469,6 +507,10 @@ impl<T: VhostUserBackendMut> VhostUserBackend for Mutex<T> {
 
     fn set_config(&self, offset: u32, buf: &[u8]) -> Result<()> {
         self.lock().unwrap().set_config(offset, buf)
+    }
+
+    fn vring_started(&self, index: u32, vring: &Self::Vring) -> Result<()> {
+        self.lock().unwrap().vring_started(index, vring)
     }
 
     fn update_memory(&self, mem: GM<Self::Bitmap>) -> Result<()> {
@@ -565,6 +607,10 @@ impl<T: VhostUserBackendMut> VhostUserBackend for RwLock<T> {
 
     fn set_config(&self, offset: u32, buf: &[u8]) -> Result<()> {
         self.write().unwrap().set_config(offset, buf)
+    }
+
+    fn vring_started(&self, index: u32, vring: &Self::Vring) -> Result<()> {
+        self.write().unwrap().vring_started(index, vring)
     }
 
     fn update_memory(&self, mem: GM<Self::Bitmap>) -> Result<()> {

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -213,7 +213,11 @@ where
     /// Adds or removes the vring's kick fd to the epoll instance based on the vring status.
     /// Ensures that notifications are handled only while the vring is both started and enabled
     /// and that no notifications are lost.
+    ///
+    /// Notifies the backend through `vring_started` when the registration is newly established,
+    /// so a backend can inspect a queue that is up but that the driver has no reason to kick.
     fn update_vring_registration(&self, vring: &T::Vring, index: u8) -> VhostUserResult<()> {
+        let mut newly_started = false;
         let vring_state = vring.get_ref();
         if let Some(fd) = vring_state.get_kick() {
             for (thread_index, queues_mask) in self.queues_per_thread.iter().enumerate() {
@@ -221,16 +225,16 @@ where
                 if shifted_queues_mask & 1u64 == 1u64 {
                     let evt_idx = queues_mask.count_ones() - shifted_queues_mask.count_ones();
                     if vring_state.get_queue().ready() && vring_state.is_enabled() {
-                        if let Err(e) = self.handlers[thread_index].register_event(
+                        match self.handlers[thread_index].register_event(
                             fd.as_raw_fd(),
                             EventSet::IN,
                             u64::from(evt_idx),
                         ) {
-                            if e.kind() != io::ErrorKind::AlreadyExists {
-                                // This could happen if we're asked by the frontend to enable an
-                                // already enabled queue, don't fail in that case.
-                                return Err(VhostUserError::ReqHandlerError(e));
-                            }
+                            Ok(()) => newly_started = true,
+                            // This could happen if we're asked by the frontend to enable an
+                            // already enabled queue, don't fail in that case.
+                            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+                            Err(e) => return Err(VhostUserError::ReqHandlerError(e)),
                         }
                     } else {
                         let _ = self.handlers[thread_index].unregister_event(
@@ -243,6 +247,17 @@ where
                 }
             }
         }
+
+        // Release the borrow before calling out: a backend acting on the vring it is handed
+        // will typically want a write guard on it.
+        drop(vring_state);
+
+        if newly_started {
+            self.backend
+                .vring_started(u32::from(index), vring)
+                .map_err(VhostUserError::ReqHandlerError)?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
`handle_event` is currently the only place a backend is handed a vring, and it
only runs when the driver rings that vring's doorbell. A queue the driver has no
reason to kick is therefore never seen by the backend at all.

That is not a corner case. A virtio-net receive queue is kicked once, at
startup, when the driver posts its receive buffers; it has no reason to kick
again. After a backend restart the replacement process never learns where that
ring lives, because SET_VRING_ADDR is handled entirely inside this crate --
`vring.set_queue_info(...)` on a `VringRwLock` the crate owns, with no callback
out. Inbound traffic then has nowhere to go until the driver happens to
transmit.

The same gap blocks inflight I/O support. `get_inflight_fd` and
`set_inflight_fd` are stubbed out here with the comment "it wouldn't be correct
for the backend to do so, as we don't (yet) provide a way for it to handle such
requests", and resubmitting orphaned descriptors after SET_INFLIGHT_FD needs
exactly this callback.

Add `vring_started`, defaulted to a no-op on both `VhostUserBackend` and
`VhostUserBackendMut`, and call it from `update_vring_registration` when the
kick fd registration is newly established -- that is, when the vring has become
both ready and enabled. Repeated SET_VRING_ENABLE requests on an already
registered vring return AlreadyExists and do not re-notify.

The callback is deliberately made after the `vring.get_ref()` borrow is
released, since a backend acting on the vring it is handed will typically want a
write guard on it.

Existing backends are unaffected: the default implementation returns Ok and the
registration path is otherwise unchanged.

This builds on commit 8c00b8829f03 ("vhost-user-backend: Avoid losing vring
kicks"), which made registration conditional on the vring being both ready and
enabled. That established a single well-defined point at which a queue becomes
live, which is where this callback fires.
