### PR TITLE
[RFC] Make Xen and non-Xen worlds compatible

### DIFF
--- a/vhost-user-backend/README.md
+++ b/vhost-user-backend/README.md
@@ -19,7 +19,7 @@ where
     V: VringT<GM<B>> + Clone + Send + Sync + 'static,
     B: Bitmap + 'static,
 {
-    pub fn new(name: String, backend: S, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap<B>>) -> Result<Self>;
+    pub fn new(name: String, backend: S, atomic_mem: GM<B>) -> Result<Self>;
     pub fn start(&mut self, listener: Listener) -> Result<()>;
     pub fn wait(&mut self) -> Result<()>;
     pub fn get_epoll_handlers(&self) -> Vec<Arc<VringEpollHandler<S, V, B>>>;

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -629,11 +629,7 @@ pub mod tests {
     use crate::VringRwLock;
     use std::sync::Mutex;
     use uuid::Uuid;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic};
-    #[cfg(not(feature = "xen"))]
-    use vm_memory::GuestMemoryMmap;
-    #[cfg(feature = "xen")]
-    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
+    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestRegionCollection, GuestRegionMmap};
 
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
@@ -787,8 +783,12 @@ pub mod tests {
         backend.get_shared_object(uuid).unwrap();
 
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
+
         backend.update_memory(mem).unwrap();
 
         backend.reset_device();
@@ -822,8 +822,12 @@ pub mod tests {
         let _ = backend.exit_event(0).unwrap();
 
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
+
         backend.update_memory(mem.clone()).unwrap();
 
         let uuid = VhostUserSharedMsg {

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -720,7 +720,7 @@ pub mod tests {
             Ok(())
         }
 
-        fn update_memory(&mut self, _atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
+        fn update_memory(&mut self, _atomic_mem: GM) -> Result<()> {
             Ok(())
         }
 

--- a/vhost-user-backend/src/backend.rs
+++ b/vhost-user-backend/src/backend.rs
@@ -629,7 +629,12 @@ pub mod tests {
     use crate::VringRwLock;
     use std::sync::Mutex;
     use uuid::Uuid;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    #[cfg(not(feature = "xen"))]
+    use vm_memory::GuestMemoryMmap;
+    #[cfg(feature = "xen")]
+    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
+
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
     pub struct MockVhostBackend {

--- a/vhost-user-backend/src/event_loop.rs
+++ b/vhost-user-backend/src/event_loop.rs
@@ -233,7 +233,11 @@ mod tests {
     use super::super::vring::VringRwLock;
     use super::*;
     use std::sync::{Arc, Mutex};
-    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    #[cfg(not(feature = "xen"))]
+    use vm_memory::GuestMemoryMmap;
+    #[cfg(feature = "xen")]
+    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
     #[test]

--- a/vhost-user-backend/src/event_loop.rs
+++ b/vhost-user-backend/src/event_loop.rs
@@ -233,17 +233,16 @@ mod tests {
     use super::super::vring::VringRwLock;
     use super::*;
     use std::sync::{Arc, Mutex};
-    use vm_memory::{GuestAddress, GuestMemoryAtomic};
-    #[cfg(not(feature = "xen"))]
-    use vm_memory::GuestMemoryMmap;
-    #[cfg(feature = "xen")]
-    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
+    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestRegionCollection, GuestRegionMmap};
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
     #[test]
     fn test_vring_epoll_handler() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let vring = VringRwLock::new(mem, 0x1000).unwrap();
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -30,13 +30,7 @@ use vhost::vhost_user::{
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Error as VirtQueError, QueueT};
 use vm_memory::mmap::NewBitmap;
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryBackend};
-
-#[cfg(not(feature = "xen"))]
-use vm_memory::{GuestRegionMmap, GuestMemoryMmap};
-#[cfg(feature = "xen")]
-use vm_memory::{GuestRegionMmapXen as GuestRegionMmap, GuestMemoryMmapXen as GuestMemoryMmap};
-
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryBackend, GuestRegionCollection};
 use vmm_sys_util::epoll::EventSet;
 
 use super::backend::VhostUserBackend;
@@ -342,13 +336,7 @@ where
         let mut mappings: Vec<AddrMapping> = Vec::new();
 
         for (region, file) in ctx.iter().zip(files) {
-            let guest_region = GuestRegionMmap::new(
-                region.mmap_region(file)?,
-                GuestAddress(region.guest_phys_addr),
-            )
-            .ok_or(VhostUserError::ReqHandlerError(
-                io::ErrorKind::InvalidInput.into(),
-            ))?;
+            let guest_region = region.memory_region(file)?;
             mappings.push(AddrMapping {
                 #[cfg(feature = "postcopy")]
                 local_addr: guest_region.as_ptr() as u64,
@@ -359,7 +347,7 @@ where
             regions.push(guest_region);
         }
 
-        let mem = GuestMemoryMmap::from_regions(regions)
+        let mem = GuestRegionCollection::from_regions(regions)
             .map_err(|e| VhostUserError::ReqHandlerError(io::Error::other(e)))?;
 
         // Updating the inner GuestMemory object here will cause all our vrings to
@@ -627,15 +615,7 @@ where
         region: &VhostUserSingleMemoryRegion,
         file: File,
     ) -> VhostUserResult<()> {
-        let guest_region = Arc::new(
-            GuestRegionMmap::new(
-                region.mmap_region(file)?,
-                GuestAddress(region.guest_phys_addr),
-            )
-            .ok_or(VhostUserError::ReqHandlerError(
-                io::ErrorKind::InvalidInput.into(),
-            ))?,
-        );
+        let guest_region = Arc::new(region.memory_region(file)?);
 
         let addr_mapping = AddrMapping {
             #[cfg(feature = "postcopy")]
@@ -826,17 +806,16 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use vhost::vhost_user::message::VhostUserVirtioFeatures;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic};
-    #[cfg(not(feature = "xen"))]
-    use vm_memory::GuestMemoryMmap;
-    #[cfg(feature = "xen")]
-    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
+    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestRegionCollection, GuestRegionMmap};
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
     #[test]
     fn test_no_lost_kicks() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut handler = VhostUserHandler::new(backend.clone(), mem.clone()).unwrap();

--- a/vhost-user-backend/src/handler.rs
+++ b/vhost-user-backend/src/handler.rs
@@ -30,9 +30,13 @@ use vhost::vhost_user::{
 use virtio_bindings::bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Error as VirtQueError, QueueT};
 use vm_memory::mmap::NewBitmap;
-use vm_memory::{
-    GuestAddress, GuestAddressSpace, GuestMemoryBackend, GuestMemoryMmap, GuestRegionMmap,
-};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryBackend};
+
+#[cfg(not(feature = "xen"))]
+use vm_memory::{GuestRegionMmap, GuestMemoryMmap};
+#[cfg(feature = "xen")]
+use vm_memory::{GuestRegionMmapXen as GuestRegionMmap, GuestMemoryMmapXen as GuestMemoryMmap};
+
 use vmm_sys_util::epoll::EventSet;
 
 use super::backend::VhostUserBackend;
@@ -822,7 +826,11 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use vhost::vhost_user::message::VhostUserVirtioFeatures;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    #[cfg(not(feature = "xen"))]
+    use vm_memory::GuestMemoryMmap;
+    #[cfg(feature = "xen")]
+    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
 
     #[test]

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -18,7 +18,12 @@ use std::thread;
 
 use vhost::vhost_user::{BackendListener, BackendReqHandler, Error as VhostUserError, Listener};
 use vm_memory::mmap::NewBitmap;
-use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::GuestMemoryAtomic;
+
+#[cfg(not(feature = "xen"))]
+use vm_memory::GuestMemoryMmap;
+#[cfg(feature = "xen")]
+use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 
 use self::handler::VhostUserHandler;
 
@@ -335,7 +340,11 @@ mod tests {
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::sync::Barrier;
     use std::time::Duration;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    #[cfg(not(feature = "xen"))]
+    use vm_memory::GuestMemoryMmap;
+    #[cfg(feature = "xen")]
+    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 
     #[test]
     fn test_new_daemon() {

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -16,16 +16,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use vhost::vhost_user::{BackendListener, BackendReqHandler, Error as VhostUserError, Listener};
-use vm_memory::mmap::NewBitmap;
-use vm_memory::GuestMemoryAtomic;
-
-#[cfg(not(feature = "xen"))]
-use vm_memory::GuestMemoryMmap;
-#[cfg(feature = "xen")]
-use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
-
 use self::handler::VhostUserHandler;
+use vhost::vhost_user::{BackendListener, BackendReqHandler, Error as VhostUserError, Listener};
+use vhost::MemoryRegion;
+use vm_memory::mmap::NewBitmap;
+use vm_memory::{GuestMemoryAtomic, GuestRegionCollection};
 
 mod backend;
 pub use self::backend::{VhostUserBackend, VhostUserBackendMut};
@@ -56,7 +51,7 @@ pub use self::vring::{
 compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
 
 /// An alias for `GuestMemoryAtomic<GuestMemoryMmap<B>>` to simplify code.
-type GM<B = ()> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
+type GM<B = ()> = GuestMemoryAtomic<GuestRegionCollection<MemoryRegion<B>>>;
 
 #[derive(Debug)]
 /// Errors related to vhost-user daemon.
@@ -336,16 +331,15 @@ mod tests {
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::sync::Barrier;
     use std::time::Duration;
-    use vm_memory::{GuestAddress, GuestMemoryAtomic};
-    #[cfg(not(feature = "xen"))]
-    use vm_memory::GuestMemoryMmap;
-    #[cfg(feature = "xen")]
-    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
+    use vm_memory::{GuestAddress, GuestRegionCollection, GuestRegionMmap};
 
     #[test]
     fn test_new_daemon() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();
@@ -378,7 +372,10 @@ mod tests {
     #[test]
     fn test_new_daemon_client() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();
@@ -413,7 +410,10 @@ mod tests {
     #[test]
     fn test_daemon_serve() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend.clone(), mem).unwrap();
@@ -458,7 +458,10 @@ mod tests {
     #[test]
     fn test_shutdown_while_connected() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();
@@ -509,7 +512,10 @@ mod tests {
     #[test]
     fn test_double_shutdown() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::from_range(GuestAddress(0x100000), 0x10000, None).unwrap(),
+            )])
+            .unwrap(),
         );
         let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
         let mut daemon = VhostUserDaemon::new("test".to_owned(), backend, mem).unwrap();

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::vring::{
 compile_error!("Both `postcopy` and `xen` features can not be enabled at the same time.");
 
 /// An alias for `GuestMemoryAtomic<GuestMemoryMmap<B>>` to simplify code.
-type GM<B> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
+type GM<B = ()> = GuestMemoryAtomic<GuestMemoryMmap<B>>;
 
 #[derive(Debug)]
 /// Errors related to vhost-user daemon.
@@ -141,11 +141,7 @@ where
     /// Under the hood, this will start a dedicated thread responsible for listening onto
     /// registered event. Those events can be vring events or custom events from the backend,
     /// but they get to be registered later during the sequence.
-    pub fn new(
-        name: String,
-        backend: T,
-        atomic_mem: GuestMemoryAtomic<GuestMemoryMmap<T::Bitmap>>,
-    ) -> Result<Self> {
+    pub fn new(name: String, backend: T, atomic_mem: GM<T::Bitmap>) -> Result<Self> {
         let handler = Arc::new(Mutex::new(
             VhostUserHandler::new(backend, atomic_mem).map_err(Error::NewVhostUserHandler)?,
         ));

--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -14,7 +14,11 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use virtio_queue::{Error as VirtQueError, Queue, QueueT};
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
+#[cfg(not(feature = "xen"))]
+use vm_memory::GuestMemoryMmap;
+#[cfg(feature = "xen")]
+use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 use vmm_sys_util::event::{EventConsumer, EventNotifier};
 
 /// Trait for objects returned by `VringT::get_ref()`.

--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -507,19 +507,17 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringRwLock<M> {
 mod tests {
     use super::*;
     use vm_memory::bitmap::AtomicBitmap;
+    use vm_memory::{GuestAddress, GuestMemoryAtomic, GuestRegionCollection, GuestRegionMmap};
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
-
-    use vm_memory::{GuestAddress, GuestMemoryAtomic};
-    #[cfg(not(feature = "xen"))]
-    use vm_memory::GuestMemoryMmap;
-    #[cfg(feature = "xen")]
-    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 
     #[test]
     fn test_new_vring() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<AtomicBitmap>::from_ranges(&[(GuestAddress(0x100000), 0x10000)])
-                .unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::<AtomicBitmap>::from_range(GuestAddress(0x100000), 0x10000, None)
+                    .unwrap(),
+            )])
+            .unwrap(),
         );
         let vring = VringMutex::new(mem, 0x1000).unwrap();
 
@@ -553,7 +551,11 @@ mod tests {
     #[test]
     fn test_vring_set_fd() {
         let mem = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0x100000), 0x10000)]).unwrap(),
+            GuestRegionCollection::from_regions(vec![vhost::MemoryRegion::Unix(
+                GuestRegionMmap::<AtomicBitmap>::from_range(GuestAddress(0x100000), 0x10000, None)
+                    .unwrap(),
+            )])
+            .unwrap(),
         );
         let vring = VringMutex::new(mem, 0x1000).unwrap();
 

--- a/vhost-user-backend/src/vring.rs
+++ b/vhost-user-backend/src/vring.rs
@@ -13,12 +13,9 @@ use std::result::Result;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crate::GM;
 use virtio_queue::{Error as VirtQueError, Queue, QueueT};
-use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic};
-#[cfg(not(feature = "xen"))]
-use vm_memory::GuestMemoryMmap;
-#[cfg(feature = "xen")]
-use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
+use vm_memory::{GuestAddress, GuestAddressSpace};
 use vmm_sys_util::event::{EventConsumer, EventNotifier};
 
 /// Trait for objects returned by `VringT::get_ref()`.
@@ -111,7 +108,7 @@ pub trait VringT<M: GuestAddressSpace>:
 ///
 /// This struct maintains all information of a virito queue, and could be used as an `VringT`
 /// object for single-threaded context.
-pub struct VringState<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>> {
+pub struct VringState<M: GuestAddressSpace = GM> {
     queue: Queue,
     kick: Option<EventConsumer>,
     call: Option<EventNotifier>,
@@ -278,7 +275,7 @@ impl<M: GuestAddressSpace> VringState<M> {
 
 /// A `VringState` object protected by Mutex for multi-threading context.
 #[derive(Clone)]
-pub struct VringMutex<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>> {
+pub struct VringMutex<M: GuestAddressSpace = GM> {
     state: Arc<Mutex<VringState<M>>>,
 }
 
@@ -393,7 +390,7 @@ impl<M: 'static + GuestAddressSpace> VringT<M> for VringMutex<M> {
 
 /// A `VringState` object protected by RwLock for multi-threading context.
 #[derive(Clone)]
-pub struct VringRwLock<M: GuestAddressSpace = GuestMemoryAtomic<GuestMemoryMmap>> {
+pub struct VringRwLock<M: GuestAddressSpace = GM> {
     state: Arc<RwLock<VringState<M>>>,
 }
 
@@ -511,6 +508,12 @@ mod tests {
     use super::*;
     use vm_memory::bitmap::AtomicBitmap;
     use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
+
+    use vm_memory::{GuestAddress, GuestMemoryAtomic};
+    #[cfg(not(feature = "xen"))]
+    use vm_memory::GuestMemoryMmap;
+    #[cfg(feature = "xen")]
+    use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 
     #[test]
     fn test_new_vring() {

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -12,15 +12,12 @@ use vhost::vhost_user::message::{
     VhostUserSharedMsg,
 };
 use vhost::vhost_user::{Backend, Frontend, Listener, VhostUserFrontend};
-use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
+use vhost::{MemoryRegion, VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
 use vm_memory::{
     FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
+    GuestMemoryMmap, GuestMemoryRegion, GuestRegionCollection,
 };
-#[cfg(not(feature = "xen"))]
-use vm_memory::GuestMemoryMmap;
-#[cfg(feature = "xen")]
-use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::event::{
     new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,
@@ -94,10 +91,13 @@ impl VhostUserBackendMut for MockVhostBackend {
         Ok(())
     }
 
-    fn update_memory(&mut self, atomic_mem: GuestMemoryAtomic<GuestMemoryMmap>) -> Result<()> {
+    fn update_memory(
+        &mut self,
+        atomic_mem: GuestMemoryAtomic<GuestRegionCollection<MemoryRegion<()>>>,
+    ) -> Result<()> {
         let mem = atomic_mem.memory();
         let region = mem.find_region(GuestAddress(0x100000)).unwrap();
-        assert_eq!(region.size(), 0x100000);
+        assert_eq!(region.len(), 0x100000);
         Ok(())
     }
 
@@ -251,7 +251,7 @@ fn vhost_user_server_with_fn<F: FnOnce(Arc<Mutex<MockVhostBackend>>, Arc<Barrier
     cb: fn(&Path, Arc<Barrier>),
     server_fn: F,
 ) {
-    let mem = GuestMemoryAtomic::new(GuestMemoryMmap::<()>::new());
+    let mem = GuestMemoryAtomic::new(GuestRegionCollection::<MemoryRegion<()>>::new());
     let backend = Arc::new(Mutex::new(MockVhostBackend::new()));
     let mut daemon = VhostUserDaemon::new("test".to_owned(), backend.clone(), mem).unwrap();
 

--- a/vhost-user-backend/tests/vhost-user-server.rs
+++ b/vhost-user-backend/tests/vhost-user-server.rs
@@ -16,8 +16,11 @@ use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock};
 use vm_memory::{
     FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
-    GuestMemoryMmap,
 };
+#[cfg(not(feature = "xen"))]
+use vm_memory::GuestMemoryMmap;
+#[cfg(feature = "xen")]
+use vm_memory::GuestMemoryMmapXen as GuestMemoryMmap;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::event::{
     new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -14,7 +14,12 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::RwLock;
 
-use vm_memory::{bitmap::Bitmap, Address, GuestMemoryRegion, GuestRegionMmap};
+use vm_memory::{bitmap::Bitmap, Address, GuestMemoryRegion};
+#[cfg(not(feature = "xen"))]
+use vm_memory::GuestRegionMmap;
+#[cfg(feature = "xen")]
+use vm_memory::GuestRegionMmapXen as GuestRegionMmap;
+
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(feature = "vhost-user")]

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -91,6 +91,22 @@ pub struct VhostUserMemoryRegionInfo {
     pub xen_mmap_data: u32,
 }
 
+#[cfg(feature = "vhost-user")]
+impl From<&VhostUserMemoryRegionInfo> for VhostUserMemoryRegion {
+    fn from(region: &VhostUserMemoryRegionInfo) -> Self {
+        VhostUserMemoryRegion {
+            guest_phys_addr: region.guest_phys_addr,
+            memory_size: region.memory_size,
+            user_addr: region.userspace_addr,
+            mmap_offset: region.mmap_offset,
+            #[cfg(feature = "xen")]
+            xen_mmap_flags: region.xen_mmap_flags,
+            #[cfg(feature = "xen")]
+            xen_mmap_data: region.xen_mmap_data,
+        }
+    }
+}
+
 impl VhostUserMemoryRegionInfo {
     /// Creates Self from GuestRegionMmap.
     pub fn from_guest_region<B: Bitmap>(region: &GuestRegionMmap<B>) -> Result<Self> {
@@ -109,28 +125,6 @@ impl VhostUserMemoryRegionInfo {
             #[cfg(feature = "xen")]
             xen_mmap_data: region.xen_mmap_data(),
         })
-    }
-
-    /// Creates VhostUserMemoryRegion from Self.
-    #[cfg(feature = "vhost-user")]
-    pub fn to_region(&self) -> VhostUserMemoryRegion {
-        #[cfg(not(feature = "xen"))]
-        return VhostUserMemoryRegion::new(
-            self.guest_phys_addr,
-            self.memory_size,
-            self.userspace_addr,
-            self.mmap_offset,
-        );
-
-        #[cfg(feature = "xen")]
-        VhostUserMemoryRegion::with_xen(
-            self.guest_phys_addr,
-            self.memory_size,
-            self.userspace_addr,
-            self.mmap_offset,
-            self.xen_mmap_flags,
-            self.xen_mmap_data,
-        )
     }
 
     /// Creates VhostUserSingleMemoryRegion from Self.

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -130,16 +130,7 @@ impl VhostUserMemoryRegionInfo {
     /// Creates VhostUserSingleMemoryRegion from Self.
     #[cfg(feature = "vhost-user")]
     pub fn to_single_region(&self) -> VhostUserSingleMemoryRegion {
-        VhostUserSingleMemoryRegion::new(
-            self.guest_phys_addr,
-            self.memory_size,
-            self.userspace_addr,
-            self.mmap_offset,
-            #[cfg(feature = "xen")]
-            self.xen_mmap_flags,
-            #[cfg(feature = "xen")]
-            self.xen_mmap_data,
-        )
+        self.into()
     }
 }
 

--- a/vhost/src/backend.rs
+++ b/vhost/src/backend.rs
@@ -14,12 +14,9 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
 use std::sync::RwLock;
 
-use vm_memory::{bitmap::Bitmap, Address, GuestMemoryRegion};
-#[cfg(not(feature = "xen"))]
-use vm_memory::GuestRegionMmap;
 #[cfg(feature = "xen")]
-use vm_memory::GuestRegionMmapXen as GuestRegionMmap;
-
+use vm_memory::GuestRegionXen;
+use vm_memory::{bitmap::Bitmap, Address, GuestMemoryRegion, GuestRegionMmap};
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(feature = "vhost-user")]
@@ -107,26 +104,47 @@ impl From<&VhostUserMemoryRegionInfo> for VhostUserMemoryRegion {
     }
 }
 
-impl VhostUserMemoryRegionInfo {
-    /// Creates Self from GuestRegionMmap.
-    pub fn from_guest_region<B: Bitmap>(region: &GuestRegionMmap<B>) -> Result<Self> {
+impl<B: Bitmap> TryFrom<&GuestRegionMmap<B>> for VhostUserMemoryRegionInfo {
+    type Error = Error;
+
+    fn try_from(region: &GuestRegionMmap<B>) -> Result<Self> {
         let file_offset = region
             .file_offset()
             .ok_or(Error::InvalidGuestMemoryRegion)?;
 
-        Ok(Self {
+        Ok(VhostUserMemoryRegionInfo {
             guest_phys_addr: region.start_addr().raw_value(),
             memory_size: region.len(),
             userspace_addr: region.as_ptr() as u64,
             mmap_offset: file_offset.start(),
             mmap_handle: file_offset.file().as_raw_fd(),
-            #[cfg(feature = "xen")]
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(feature = "xen")]
+impl<B: Bitmap> TryFrom<&GuestRegionXen<B>> for VhostUserMemoryRegionInfo {
+    type Error = Error;
+
+    fn try_from(region: &GuestRegionXen<B>) -> std::result::Result<Self, Self::Error> {
+        let file_offset = region
+            .file_offset()
+            .ok_or(Error::InvalidGuestMemoryRegion)?;
+
+        Ok(VhostUserMemoryRegionInfo {
+            guest_phys_addr: region.start_addr().raw_value(),
+            memory_size: region.len(),
+            userspace_addr: region.as_ptr() as u64,
+            mmap_offset: file_offset.start(),
+            mmap_handle: file_offset.file().as_raw_fd(),
             xen_mmap_flags: region.xen_mmap_flags(),
-            #[cfg(feature = "xen")]
             xen_mmap_data: region.xen_mmap_data(),
         })
     }
+}
 
+impl VhostUserMemoryRegionInfo {
     /// Creates VhostUserSingleMemoryRegion from Self.
     #[cfg(feature = "vhost-user")]
     pub fn to_single_region(&self) -> VhostUserSingleMemoryRegion {

--- a/vhost/src/lib.rs
+++ b/vhost/src/lib.rs
@@ -30,15 +30,23 @@
 //! that shares its virtqueues. Backend is the consumer of the virtqueues. Frontend and backend can be
 //! either a client (i.e. connecting) or server (listening) in the socket communication.
 
-#![deny(missing_docs)]
-
 #[cfg_attr(feature = "vhost-user", macro_use)]
 extern crate bitflags;
 #[cfg_attr(feature = "vhost-kern", macro_use)]
 extern crate vmm_sys_util;
 
 mod backend;
+
+use std::ops::Deref;
+
 pub use backend::*;
+use vm_memory::bitmap::{Bitmap, BS};
+#[cfg(feature = "xen")]
+use vm_memory::GuestRegionXen;
+use vm_memory::{
+    GuestAddress, GuestMemoryRegion, GuestMemoryRegionBytes, GuestRegionMmap, GuestUsize,
+    MemoryRegionAddress, VolatileSlice,
+};
 
 #[cfg(feature = "vhost-net")]
 pub mod net;
@@ -132,6 +140,75 @@ impl std::convert::From<vhost_user::Error> for Error {
 
 /// Result of vhost operations
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub enum MemoryRegion<B> {
+    Unix(GuestRegionMmap<B>),
+    #[cfg(feature = "xen")]
+    Xen(GuestRegionXen<B>),
+}
+
+impl<B: Bitmap> MemoryRegion<B> {
+    pub fn bitmap(&self) -> &B {
+        match self {
+            MemoryRegion::Unix(r) => (*r).deref().bitmap(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.bitmap(),
+        }
+    }
+}
+
+impl<B: Bitmap> GuestMemoryRegion for MemoryRegion<B> {
+    type B = B;
+
+    fn len(&self) -> GuestUsize {
+        match self {
+            MemoryRegion::Unix(r) => r.len(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.len(),
+        }
+    }
+
+    fn start_addr(&self) -> GuestAddress {
+        match self {
+            MemoryRegion::Unix(r) => r.start_addr(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.start_addr(),
+        }
+    }
+
+    fn bitmap(&self) -> BS<'_, Self::B> {
+        match self {
+            MemoryRegion::Unix(r) => r.bitmap(),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => <GuestRegionXen<B> as GuestMemoryRegion>::bitmap(r),
+        }
+    }
+
+    fn get_host_address(
+        &self,
+        addr: MemoryRegionAddress,
+    ) -> vm_memory::guest_memory::Result<*mut u8> {
+        match self {
+            MemoryRegion::Unix(r) => r.get_host_address(addr),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.get_host_address(addr),
+        }
+    }
+
+    fn get_slice(
+        &self,
+        offset: MemoryRegionAddress,
+        count: usize,
+    ) -> vm_memory::guest_memory::Result<VolatileSlice<'_, BS<'_, Self::B>>> {
+        match self {
+            MemoryRegion::Unix(r) => r.get_slice(offset, count),
+            #[cfg(feature = "xen")]
+            MemoryRegion::Xen(r) => r.get_slice(offset, count),
+        }
+    }
+}
+
+impl<B: Bitmap> GuestMemoryRegionBytes for MemoryRegion<B> {}
 
 #[cfg(test)]
 mod tests {

--- a/vhost/src/vhost_user/frontend.rs
+++ b/vhost/src/vhost_user/frontend.rs
@@ -241,7 +241,7 @@ impl VhostBackend for Frontend {
                 return error_code(VhostUserError::InvalidParam);
             }
 
-            ctx.append(&region.to_region(), region.mmap_handle);
+            ctx.append(&region.into(), region.mmap_handle);
         }
 
         let mut node = self.node();

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -25,7 +25,7 @@ use vm_memory::MmapRegion;
 use vm_memory::{GuestAddress, GuestRegionXen, MmapRangeXen, MmapXenFlags};
 
 use super::{enum_value, Error, Result};
-use crate::VringConfigData;
+use crate::{VhostUserMemoryRegionInfo, VringConfigData};
 
 /*
 TODO: Consider deprecating this. We don't actually have any preallocated buffers except in tests,
@@ -652,43 +652,12 @@ impl Deref for VhostUserSingleMemoryRegion {
     }
 }
 
-#[cfg(not(feature = "xen"))]
-impl VhostUserSingleMemoryRegion {
-    /// Create a new instance.
-    pub fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
+#[cfg(feature = "vhost-user")]
+impl From<&VhostUserMemoryRegionInfo> for VhostUserSingleMemoryRegion {
+    fn from(value: &VhostUserMemoryRegionInfo) -> Self {
         VhostUserSingleMemoryRegion {
             padding: 0,
-            region: VhostUserMemoryRegion::new(
-                guest_phys_addr,
-                memory_size,
-                user_addr,
-                mmap_offset,
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "xen")]
-impl VhostUserSingleMemoryRegion {
-    /// Create a new instance.
-    pub fn new(
-        guest_phys_addr: u64,
-        memory_size: u64,
-        user_addr: u64,
-        mmap_offset: u64,
-        xen_mmap_flags: u32,
-        xen_mmap_data: u32,
-    ) -> Self {
-        VhostUserSingleMemoryRegion {
-            padding: 0,
-            region: VhostUserMemoryRegion::with_xen(
-                guest_phys_addr,
-                memory_size,
-                user_addr,
-                mmap_offset,
-                xen_mmap_flags,
-                xen_mmap_data,
-            ),
+            region: value.into(),
         }
     }
 }

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -17,15 +17,15 @@ use std::ops::Deref;
 
 use uuid::Uuid;
 
-use vm_memory::{mmap::NewBitmap, ByteValued, FileOffset};
+use vm_memory::{
+    mmap::NewBitmap, ByteValued, FileOffset, GuestAddress, GuestRegionMmap, MmapRegion,
+};
 
-#[cfg(not(feature = "xen"))]
-use vm_memory::MmapRegion;
 #[cfg(feature = "xen")]
-use vm_memory::{GuestAddress, GuestRegionXen, MmapRangeXen, MmapXenFlags};
+use vm_memory::{GuestRegionXen, MmapRangeXen, MmapXenFlags};
 
 use super::{enum_value, Error, Result};
-use crate::{VhostUserMemoryRegionInfo, VringConfigData};
+use crate::{MemoryRegion, VhostUserMemoryRegionInfo, VringConfigData};
 
 /*
 TODO: Consider deprecating this. We don't actually have any preallocated buffers except in tests,
@@ -546,49 +546,61 @@ impl VhostUserMemoryRegion {
             && self.user_addr.checked_add(self.memory_size).is_some()
             && self.mmap_offset.checked_add(self.memory_size).is_some()
     }
-}
 
-#[cfg(not(feature = "xen"))]
-impl VhostUserMemoryRegion {
-    /// Creates mmap region from Self.
-    pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<MmapRegion<B>> {
-        MmapRegion::<B>::from_file(
-            FileOffset::new(file, self.mmap_offset),
-            self.memory_size as usize,
-        )
-        .map_err(|e| Error::ReqHandlerError(io::Error::other(e)))
+    fn is_xen(&self) -> bool {
+        #[cfg(feature = "xen")]
+        {
+            !(self.xen_mmap_flags == 0 && self.xen_mmap_data == 0)
+        }
+        #[cfg(not(feature = "xen"))]
+        {
+            false
+        }
     }
 
-    fn is_valid(&self) -> bool {
-        self.is_valid_common()
-    }
-}
+    pub fn memory_region<B: NewBitmap>(&self, file: File) -> Result<MemoryRegion<B>> {
+        let size = self.memory_size as usize;
+        let guest_addr = GuestAddress(self.guest_phys_addr);
 
-#[cfg(feature = "xen")]
-impl VhostUserMemoryRegion {
-    /// Creates mmap region from Self.
-    pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<GuestRegionXen<B>> {
-        let range = MmapRangeXen::new(
-            self.memory_size as usize,
-            Some(FileOffset::new(file, self.mmap_offset)),
-            GuestAddress(self.guest_phys_addr),
-            self.xen_mmap_flags,
-            self.xen_mmap_data,
-        );
+        #[cfg(feature = "xen")]
+        if self.is_xen() {
+            let range = MmapRangeXen::new(
+                size,
+                Some(FileOffset::new(file, self.mmap_offset)),
+                guest_addr,
+                self.xen_mmap_flags,
+                self.xen_mmap_data,
+            );
 
-        GuestRegionXen::<B>::from_range(range).map_err(|e| Error::ReqHandlerError(io::Error::other(e)))
+            return GuestRegionXen::<B>::from_range(range)
+                .map_err(|e| Error::ReqHandlerError(io::Error::other(e)))
+                .map(MemoryRegion::Xen);
+        }
+
+        MmapRegion::from_file(FileOffset::new(file, self.mmap_offset), size)
+            .map_err(|e| Error::ReqHandlerError(io::Error::other(e)))
+            .and_then(|region| {
+                GuestRegionMmap::new(region, guest_addr)
+                    .ok_or(Error::ReqHandlerError(io::Error::other(
+                        "invalid memory region",
+                    )))
+                    .map(MemoryRegion::Unix)
+            })
     }
 
     fn is_valid(&self) -> bool {
         if !self.is_valid_common() {
-            false
-        } else {
-            // Only of one of FOREIGN or GRANT should be set.
-            match MmapXenFlags::from_bits(self.xen_mmap_flags) {
-                Some(flags) => flags.is_valid(),
-                None => false,
-            }
+            return false;
         }
+
+        #[cfg(feature = "xen")]
+        if self.is_xen() {
+            // Only of one of FOREIGN or GRANT should be set.
+            return MmapXenFlags::from_bits(self.xen_mmap_flags)
+                .is_none_or(|flags| flags.is_valid());
+        }
+
+        true
     }
 }
 

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -17,10 +17,12 @@ use std::ops::Deref;
 
 use uuid::Uuid;
 
-use vm_memory::{mmap::NewBitmap, ByteValued, FileOffset, MmapRegion};
+use vm_memory::{mmap::NewBitmap, ByteValued, FileOffset};
 
+#[cfg(not(feature = "xen"))]
+use vm_memory::MmapRegion;
 #[cfg(feature = "xen")]
-use vm_memory::{GuestAddress, MmapRange, MmapXenFlags};
+use vm_memory::{GuestAddress, GuestRegionXen, MmapRangeXen, MmapXenFlags};
 
 use super::{enum_value, Error, Result};
 use crate::VringConfigData;
@@ -594,8 +596,8 @@ impl VhostUserMemoryRegion {
     }
 
     /// Creates mmap region from Self.
-    pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<MmapRegion<B>> {
-        let range = MmapRange::new(
+    pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<GuestRegionXen<B>> {
+        let range = MmapRangeXen::new(
             self.memory_size as usize,
             Some(FileOffset::new(file, self.mmap_offset)),
             GuestAddress(self.guest_phys_addr),
@@ -603,7 +605,7 @@ impl VhostUserMemoryRegion {
             self.xen_mmap_data,
         );
 
-        MmapRegion::<B>::from_range(range).map_err(|e| Error::ReqHandlerError(io::Error::other(e)))
+        GuestRegionXen::<B>::from_range(range).map_err(|e| Error::ReqHandlerError(io::Error::other(e)))
     }
 
     fn is_valid(&self) -> bool {

--- a/vhost/src/vhost_user/message.rs
+++ b/vhost/src/vhost_user/message.rs
@@ -550,16 +550,6 @@ impl VhostUserMemoryRegion {
 
 #[cfg(not(feature = "xen"))]
 impl VhostUserMemoryRegion {
-    /// Create a new instance.
-    pub fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
-        VhostUserMemoryRegion {
-            guest_phys_addr,
-            memory_size,
-            user_addr,
-            mmap_offset,
-        }
-    }
-
     /// Creates mmap region from Self.
     pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<MmapRegion<B>> {
         MmapRegion::<B>::from_file(
@@ -576,25 +566,6 @@ impl VhostUserMemoryRegion {
 
 #[cfg(feature = "xen")]
 impl VhostUserMemoryRegion {
-    /// Create a new instance.
-    pub fn with_xen(
-        guest_phys_addr: u64,
-        memory_size: u64,
-        user_addr: u64,
-        mmap_offset: u64,
-        xen_mmap_flags: u32,
-        xen_mmap_data: u32,
-    ) -> Self {
-        VhostUserMemoryRegion {
-            guest_phys_addr,
-            memory_size,
-            user_addr,
-            mmap_offset,
-            xen_mmap_flags,
-            xen_mmap_data,
-        }
-    }
-
     /// Creates mmap region from Self.
     pub fn mmap_region<B: NewBitmap>(&self, file: File) -> Result<GuestRegionXen<B>> {
         let range = MmapRangeXen::new(
@@ -1187,20 +1158,6 @@ mod tests {
     use super::*;
     use std::mem;
 
-    #[cfg(feature = "xen")]
-    impl VhostUserMemoryRegion {
-        fn new(guest_phys_addr: u64, memory_size: u64, user_addr: u64, mmap_offset: u64) -> Self {
-            Self::with_xen(
-                guest_phys_addr,
-                memory_size,
-                user_addr,
-                mmap_offset,
-                MmapXenFlags::FOREIGN.bits(),
-                0,
-            )
-        }
-    }
-
     #[test]
     fn check_transfer_state_direction_code() {
         let load_code: u32 = VhostTransferStateDirection::LOAD.into();
@@ -1322,7 +1279,15 @@ mod tests {
 
     #[test]
     fn check_user_memory_region() {
-        let mut msg = VhostUserMemoryRegion::new(0, 0x1000, 0, 0);
+        let mut msg = VhostUserMemoryRegion {
+            guest_phys_addr: 0,
+            memory_size: 0x1000,
+            user_addr: 0,
+            mmap_offset: 0,
+            #[cfg(feature = "xen")]
+            xen_mmap_flags: MmapXenFlags::FOREIGN.bits(),
+            ..Default::default()
+        };
         assert!(msg.is_valid());
         msg.guest_phys_addr = 0xFFFFFFFFFFFFEFFF;
         assert!(msg.is_valid());


### PR DESCRIPTION
### Summary of the PR

[ based on https://github.com/rust-vmm/rust-vmm/pull/108 and replaces https://github.com/rust-vmm/vhost/pull/325]

Fix up the xen feature such that compiling with --feature xen allows serving both xen and non-xen VMMs. Whether or not we are dealing with a xen frontend is determined by inspecting the control messages (if the xen fields are around, then construct GuestRegionXen', otherwise just use plain old GuestRegionMmap` (unix)).

The first few commits are just cleanups that could probably be merged as is, but I'm not too sure whether they mess up the crates' API or not.

As for how to test this, you'll need a [patch.crates-io] for vm-memory pointed to a checkout of the above PR.

I also had a quick go at compile testing this against vhost-device, but vmm-sys-util incompatibilities were the only errors I got (apart from some needed changes from GuestMemoryMmap to GuestMemoryCollection).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
